### PR TITLE
Create clang-format.yaml

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -1,0 +1,16 @@
+name: clang-format linting
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
+      with:
+        source: '.'
+        exclude: './lib'
+        extensions: 'h,c'
+        clangFormatVersion: 16

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -1,3 +1,1 @@
-const char* callsign(char **argv) {
-    return argv[1];
-}
+const char *callsign(char **argv) { return argv[1]; }


### PR DESCRIPTION
This workflow will check if committed code follows the format specified in `.clang-format`.