### PR TITLE
Updated C standard

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14,7 +14,7 @@ endef
 NAME=packager
 
 ### COMPILER OPTIONS ###
-CSTD = c11
+CSTD = gnu11
 OPTIMIZATION = -O2
 
 ### WARNINGS ###

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "packet_types.h"
+#include <getopt.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,17 +9,17 @@ static char *callsign = NULL;
 int main(int argc, char **argv) {
 
     /* Fetch command line arguments. */
-    /* int c; */
-    /* while ((c = getopt(argc, argv, "c:")) != -1) { */
-    /*     switch (c) { */
-    /*     case 'c': */
-    /*         callsign = optarg; */
-    /*         break; */
-    /*     default: */
-    /*         fputs("Please see the 'use' page for usage.", stderr); */
-    /*         return EXIT_FAILURE; */
-    /*     } */
-    /* } */
+    int c;
+    while ((c = getopt(argc, argv, "c:")) != -1) {
+        switch (c) {
+        case 'c':
+            callsign = optarg;
+            break;
+        default:
+            fputs("Please see the 'use' page for usage.", stderr);
+            return EXIT_FAILURE;
+        }
+    }
 
     PacketHeader h;
     packet_header_init(&h, "VA3INI", 0, 0, ROCKET, 1);


### PR DESCRIPTION
Updated C standard to be `gnu11` in order to use GNU libraries (such as getopt).

This PR will also advance progress on #6, which is now possible with the inclusion of `getopt.h`.