### PR TITLE
Change Doxygen generation to only happen when a pull request is merged.

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -1,6 +1,11 @@
 name: Doxygen
 
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This pull request changes the Doxygen workflow to only run when a pull request is merged. This is to prevent unfinished features from showing up in the main docs, and also prevent pull requests which are rejected from changing the main docs.