### PR TITLE
Blocks and packets

### DIFF
--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -82,19 +82,19 @@ typedef struct packet_header {
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t length, const uint8_t version,
                         const DeviceAddress source, const uint16_t packet_number);
-inline uint16_t packet_header_get_length(const PacketHeader *p);
-inline void packet_header_set_length(PacketHeader *p, uint16_t length);
+uint16_t packet_header_get_length(const PacketHeader *p);
+void packet_header_set_length(PacketHeader *p, uint16_t length);
 
 /** Each block in the radio packet will have a header in this format. */
 typedef struct block_header {
     /** The block header accessed as a bytes array. */
-    uint16_t bytes[4];
+    uint8_t bytes[4];
 } BlockHeader;
 
 void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig, const BlockType type,
                        const BlockSubtype subtype, const DeviceAddress dest);
-inline uint16_t block_header_get_length(const BlockHeader *p);
-inline void block_header_set_length(BlockHeader *p, const uint16_t length);
+uint16_t block_header_get_length(const BlockHeader *p);
+void block_header_set_length(BlockHeader *p, const uint16_t length);
 
 /** Signal report for the last block that was sent by the block's destination device */
 typedef union signal_report_block {

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -82,6 +82,8 @@ typedef struct packet_header {
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint8_t length, const uint8_t version,
                         const DeviceAddress source, const uint16_t packet_number);
+inline uint8_t packet_header_get_length(PacketHeader *p);
+inline void packet_header_set_length(PacketHeader *p, uint8_t length);
 
 /** Each block in the radio packet will have a header in this format. */
 typedef struct block_header {

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -80,19 +80,21 @@ typedef struct packet_header {
     uint8_t bytes[12];
 } PacketHeader;
 
-void packet_header_init(PacketHeader *p, const char *callsign, const uint8_t length, const uint8_t version,
+void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t length, const uint8_t version,
                         const DeviceAddress source, const uint16_t packet_number);
-inline uint8_t packet_header_get_length(PacketHeader *p);
-inline void packet_header_set_length(PacketHeader *p, uint8_t length);
+inline uint16_t packet_header_get_length(const PacketHeader *p);
+inline void packet_header_set_length(PacketHeader *p, uint16_t length);
 
 /** Each block in the radio packet will have a header in this format. */
 typedef struct block_header {
     /** The block header accessed as a bytes array. */
-    uint8_t bytes[4];
+    uint16_t bytes[4];
 } BlockHeader;
 
-void block_header_init(BlockHeader *b, const uint8_t length, const bool has_sig, const BlockType type,
+void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig, const BlockType type,
                        const BlockSubtype subtype, const DeviceAddress dest);
+inline uint16_t block_header_get_length(const BlockHeader *p);
+inline void block_header_set_length(BlockHeader *p, const uint16_t length);
 
 /** Signal report for the last block that was sent by the block's destination device */
 typedef union signal_report_block {
@@ -150,5 +152,7 @@ typedef struct {
     /** Packet contents in blocks, up to 256 bytes long. */
     Block *blocks;
 } TIGHTLY_PACKED Packet;
+
+bool packet_append_block(Packet *p, Block *b);
 
 #endif // _PACKET_TYPES_H

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -155,6 +155,6 @@ typedef struct {
     Block *blocks;
 } TIGHTLY_PACKED Packet;
 
-bool packet_append_block(Packet *p, Block *b);
+bool packet_append_block(Packet *p, const Block b);
 
 #endif // _PACKET_TYPES_H

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -128,7 +128,7 @@ typedef struct altitude_data_block {
 } AltitudeDataBlock;
 
 void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
-                              const uint32_t temperature, const uint32_t altitude);
+                              const int32_t temperature, const int32_t altitude);
 
 typedef struct angular_velocity_block {
     /**The angular velocity block accessed as a bytes array*/

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -23,6 +23,8 @@
 #define TIGHTLY_PACKED __attribute__((packed, aligned(1)))
 #endif
 
+void memcpy_be(void *dest, const void *src, unsigned long n_bytes);
+
 /** Possible devices from which a packet could originate or be sent to. */
 typedef enum device_address {
     GROUNDSTATION = 0x0, /**< Ground station */

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -75,50 +75,18 @@ typedef enum data_block_type {
 typedef uint8_t BlockSubtype;
 
 /** Each radio packet will have a header in this format. */
-typedef union packet_header {
+typedef struct packet_header {
     /** The packet header accessed as a bytes array. */
     uint8_t bytes[12];
-    /** Individually accessible components of the block header's contents. */
-    struct {
-        /** Amateur radio call sign of the operator. */
-        uint8_t callsign[6];
-        /** The length of the packet in bytes (including the header). */
-        uint8_t length : 6;
-        /** The version of the radio packet format being used. */
-        uint8_t version : 5;
-        uint8_t _dead_space : 5;
-        /** The source address of the packet. */
-        DeviceAddress src_addr : 4;
-        /** Which packet number the packet is in the stream being sent over radio. */
-        uint16_t packet_number : 12;
-        uint16_t _dead_space_2 : 16;
-    } TIGHTLY_PACKED contents;
 } PacketHeader;
-
-/** Casts the 8-bit ASCII call sign value to a null-terminated string. */
-#define packet_callsign(p) ((char *)p.contents.callsign)
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint8_t length, const uint8_t version,
                         const DeviceAddress source, const uint16_t packet_number);
 
 /** Each block in the radio packet will have a header in this format. */
-typedef union block_header {
+typedef struct block_header {
     /** The block header accessed as a bytes array. */
     uint8_t bytes[4];
-    /** Individually accessible components of the packet header. */
-    struct {
-        /** The length of the block in bytes. */
-        uint8_t length : 5;
-        /** Whether or not the block has a cryptographic signature. */
-        bool has_sig : 1;
-        /** The type of block. */
-        BlockType type : 4;
-        /** The block type's subtype. */
-        BlockSubtype subtype : 6;
-        /** The device address of the destination. */
-        DeviceAddress dest : 4;
-        uint16_t _dead_space : 12;
-    } TIGHTLY_PACKED contents;
 } BlockHeader;
 
 void block_header_init(BlockHeader *b, const uint8_t length, const bool has_sig, const BlockType type,
@@ -151,7 +119,7 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
 typedef struct altitude_data_block {
     /**The altitude data block accessed as a bytes array*/
     uint8_t bytes[16];
-} TIGHTLY_PACKED AltitudeDataBlock;
+} AltitudeDataBlock;
 
 void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
                               const uint32_t temperature, const uint32_t altitude);
@@ -159,9 +127,26 @@ void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_t
 typedef struct angular_velocity_block {
     /**The angular velocity block accessed as a bytes array*/
     uint8_t bytes[12];
-} TIGHTLY_PACKED AngularVelocityBlock;
+} AngularVelocityBlock;
 
 void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measurement_time,
                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                  const int16_t z_axis);
+
+/** Represents a radio packet block with variable length contents. */
+typedef struct {
+    /** The block header. Block length is encoded here. */
+    BlockHeader header;
+    /** The block contents up to a length of 128 bytes. */
+    uint8_t *contents;
+} TIGHTLY_PACKED Block;
+
+/** Represents a packet with a variable number of blocks. Maximum of 256 bytes. */
+typedef struct {
+    /** The packet header. Packet length is encoded here. */
+    PacketHeader header;
+    /** Packet contents in blocks, up to 256 bytes long. */
+    Block *blocks;
+} TIGHTLY_PACKED Packet;
+
 #endif // _PACKET_TYPES_H

--- a/src/main.c
+++ b/src/main.c
@@ -42,23 +42,21 @@ int main(int argc, char **argv) {
 
     PacketHeader header;
     packet_header_init(&header, callsign, 0, 0, ROCKET, 256);
-    printf("Packet header\n");
-    debug_print_bytes(header.bytes, sizeof(PacketHeader));
 
     BlockHeader header_b;
-    block_header_init(&header_b, 0, true, TYPE_DATA, DATA_ALT, ROCKET);
-    printf("Block header\n");
-    debug_print_bytes(header_b.bytes, sizeof(BlockHeader));
+    block_header_init(&header_b, sizeof(AltitudeDataBlock), true, TYPE_DATA, DATA_ALT, ROCKET);
 
     AltitudeDataBlock a;
     altitude_data_block_init(&a, 1, 12, 18, 17);
-    printf("Altitude data block\n");
     debug_print_bytes(a.bytes, sizeof(AltitudeDataBlock));
 
     Block b = {.header = header_b, .contents = (uint8_t *)&a};
-    uint8_t blocks[sizeof(Block)] = {0};
-    Packet p = {.header = header, .blocks = (Block *)blocks};
-    packet_append_block(&p, &b);
+    Block blocks[2] = {0};
+    Packet p = {.header = header, .blocks = blocks};
+    packet_append_block(&p, b);
+
+    printf("Block contents\n");
+    debug_print_bytes(p.blocks[0].contents, block_header_get_length(&p.blocks[0].header) - sizeof(BlockHeader));
 
     /* Open input stream. */
     FILE *input;

--- a/src/main.c
+++ b/src/main.c
@@ -40,24 +40,6 @@ int main(int argc, char **argv) {
     }
     callsign = argv[optind];
 
-    PacketHeader header;
-    packet_header_init(&header, callsign, 0, 0, ROCKET, 256);
-
-    BlockHeader header_b;
-    block_header_init(&header_b, sizeof(AltitudeDataBlock), true, TYPE_DATA, DATA_ALT, ROCKET);
-
-    AltitudeDataBlock a;
-    altitude_data_block_init(&a, 1, 12, 18, 17);
-    debug_print_bytes(a.bytes, sizeof(AltitudeDataBlock));
-
-    Block b = {.header = header_b, .contents = (uint8_t *)&a};
-    Block blocks[2] = {0};
-    Packet p = {.header = header, .blocks = blocks};
-    packet_append_block(&p, b);
-
-    printf("Block contents\n");
-    debug_print_bytes(p.blocks[0].contents, block_header_get_length(&p.blocks[0].header) - sizeof(BlockHeader));
-
     /* Open input stream. */
     FILE *input;
     if (file != NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,8 @@ static char *callsign = NULL;
 static char *file = NULL;
 static char buffer[BUFFER_SIZE] = {0};
 
+void debug_print_bytes(uint8_t *bytes, size_t n_bytes);
+
 int main(int argc, char **argv) {
 
     /* Fetch command line arguments. */
@@ -38,6 +40,26 @@ int main(int argc, char **argv) {
     }
     callsign = argv[optind];
 
+    PacketHeader header;
+    packet_header_init(&header, callsign, 0, 0, ROCKET, 256);
+    printf("Packet header\n");
+    debug_print_bytes(header.bytes, sizeof(PacketHeader));
+
+    BlockHeader header_b;
+    block_header_init(&header_b, 0, true, TYPE_DATA, DATA_ALT, ROCKET);
+    printf("Block header\n");
+    debug_print_bytes(header_b.bytes, sizeof(BlockHeader));
+
+    AltitudeDataBlock a;
+    altitude_data_block_init(&a, 1, 12, 18, 17);
+    printf("Altitude data block\n");
+    debug_print_bytes(a.bytes, sizeof(AltitudeDataBlock));
+
+    Block b = {.header = header_b, .contents = (uint8_t *)&a};
+    uint8_t blocks[sizeof(Block)] = {0};
+    Packet p = {.header = header, .blocks = (Block *)blocks};
+    packet_append_block(&p, &b);
+
     /* Open input stream. */
     FILE *input;
     if (file != NULL) {
@@ -56,4 +78,11 @@ int main(int argc, char **argv) {
     }
 
     return EXIT_SUCCESS;
+}
+
+void debug_print_bytes(uint8_t *bytes, size_t n_bytes) {
+    for (size_t i = 0; i < n_bytes; i++) {
+        printf("%02x ", bytes[i]);
+    }
+    putchar('\n');
 }

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -32,7 +32,7 @@ void packet_header_init(PacketHeader *p, const char *callsign, const uint8_t len
         p->bytes[i] = callsign[i];
     }
 
-    p->bytes[6] = (uint8_t)((length & 0x3F) << 2);   // Last 6 bits only, but shifted to start of byte
+    packet_header_set_length(p, length);
     p->bytes[6] |= (uint8_t)((version & 0x18) >> 3); // First two bits of version right after length
     p->bytes[7] = (uint8_t)((version & 0x07) << 5);  // Last three bits of version at start of byte
     // Remaining 5 bits in byte 8 are dead space
@@ -42,6 +42,22 @@ void packet_header_init(PacketHeader *p, const char *callsign, const uint8_t len
     p->bytes[10] = 0;                                        // Dead space
     p->bytes[11] = 0;                                        // Dead space
 }
+
+/**
+ * Sets the length of the packet header.
+ * @param p The packet header to store the length in.
+ * @param length The length of the packet header.
+ */
+inline void packet_header_set_length(PacketHeader *p, uint8_t length) {
+    p->bytes[6] = (uint8_t)((length & 0x3F) << 2); // Last 6 bits only, but shifted to start of byte
+}
+
+/**
+ * Gets the length stored in the packet header.
+ * @param p The packet header to read the length from.
+ * @return The length stored in the packet header.
+ */
+inline uint8_t packet_header_get_length(PacketHeader *p) { return (p->bytes[6] & 0xFC) >> 2; }
 
 /**
  * Initializes a block header with the provided information.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -8,7 +8,6 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 /** The maximum size of a packet in bytes. */
@@ -21,7 +20,7 @@ static const uint16_t PACKET_MAX_SIZE = 256;
  */
 void memcpy_be(void *dest, const void *src, unsigned long n_bytes) {
     for (unsigned long i = n_bytes; i > 0; i--) {
-        ((uint8_t *)dest)[n_bytes - i - 1] = ((const uint8_t *)src)[i];
+        ((uint8_t *)dest)[n_bytes - i] = ((const uint8_t *)src)[i - 1];
     }
 }
 
@@ -140,18 +139,13 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
 /**
  * Initializes an altitude data block with the provided information.
  * @param b The altitude data to be initialized
- * @param measurement_time The mission time at the taking of the measurment
- * @param pressure The measured pressure in terms of Pascals. This field is a signed 32 bit integer in two's complement
- * format.
- * @param temperature The measured temperature in units of 1 millidegree Celsius/LSB. This field is a signed 32 bit
- * integer in two's complement format.
- * @param altitude The calculated altitude in units of 1 mm/LSB. This field is a signed 32 bit integer in two’s
- * complement format.
+ * @param measurement_time The mission time at the taking of the measurement
+ * @param pressure The measured pressure in terms of Pascals.
+ * @param temperature The measured temperature in units of 1 millidegree Celsius/LSB.
+ * @param altitude The calculated altitude in units of 1 mm/LSB.
  */
 void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
-                              const uint32_t temperature, const uint32_t altitude) {
-    printf("%u\n", altitude);
-    printf("%lu\n", sizeof(measurement_time) + sizeof(pressure) + sizeof(temperature));
+                              const int32_t temperature, const int32_t altitude) {
     memcpy_be(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy_be(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
     memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(pressure), &temperature, sizeof(temperature));

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -13,6 +13,17 @@
 /** The maximum size of a packet in bytes. */
 static const uint16_t PACKET_MAX_SIZE = 256;
 
+/* Copies memory from source to destination in big endian format.
+ * @param dest The destination buffer.
+ * @param src The source buffer.
+ * @param n_bytes The size of the source buffer in bytes.
+ */
+void memcpy_be(void *dest, const void *src, unsigned long n_bytes) {
+    for (unsigned long i = n_bytes; i > 0; i--) {
+        ((uint8_t *)dest)[n_bytes - i] = ((const uint8_t *)src)[i];
+    }
+}
+
 /**
  * Initializes a packet header with the provided information.
  *
@@ -138,10 +149,10 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
  */
 void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
                               const uint32_t temperature, const uint32_t altitude) {
-    memcpy(b->bytes, &measurement_time, sizeof(uint32_t));
-    memcpy(b->bytes + 4, &pressure, sizeof(uint32_t));
-    memcpy(b->bytes + 8, &temperature, sizeof(uint32_t));
-    memcpy(b->bytes + 12, &altitude, sizeof(uint32_t));
+    memcpy_be(b->bytes, &measurement_time, sizeof(uint32_t));
+    memcpy_be(b->bytes + 4, &pressure, sizeof(uint32_t));
+    memcpy_be(b->bytes + 8, &temperature, sizeof(uint32_t));
+    memcpy_be(b->bytes + 12, &altitude, sizeof(uint32_t));
 }
 /**
  * Initializes an angular velocity block with the provided information.
@@ -156,11 +167,11 @@ void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_t
 void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measurement_time,
                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                  const int16_t z_axis) {
-    memcpy(b->bytes, &measurement_time, sizeof(uint32_t));
-    memcpy(b->bytes + 4, &full_scale_range, sizeof(uint8_t));
-    memcpy(b->bytes + 5, &x_axis, sizeof(uint16_t));
-    memcpy(b->bytes + 7, &y_axis, sizeof(uint16_t));
-    memcpy(b->bytes + 9, &z_axis, sizeof(uint16_t));
+    memcpy_be(b->bytes, &measurement_time, sizeof(uint32_t));
+    memcpy_be(b->bytes + 4, &full_scale_range, sizeof(uint8_t));
+    memcpy_be(b->bytes + 5, &x_axis, sizeof(uint16_t));
+    memcpy_be(b->bytes + 7, &y_axis, sizeof(uint16_t));
+    memcpy_be(b->bytes + 9, &z_axis, sizeof(uint16_t));
 }
 
 /**
@@ -181,6 +192,6 @@ bool packet_append_block(Packet *p, Block *b) {
 
     // Necessary to cast blocks to uint8_t pointer so that offset is computed in bytes rather than sizeof(Block)
     uint8_t *end_of_blocks = ((uint8_t *)p->blocks) + (p_len + sizeof(PacketHeader));
-    memcpy(end_of_blocks, b, b_len);
+    memcpy_be(end_of_blocks, b, b_len);
     return true;
 }


### PR DESCRIPTION
This pull request adds support for the primary block and packet types, which represent all blocks and all packets.

There is now an appending function for packets that allows blocks to be appended easily, while updating the packet length in its header.

This PR also corrects several issues, such as incorrect function parameter types when compared with the packet spec, poor `memcpy` hygiene and incorrect doc strings.

**NOTE:** This PR makes the addition of a `memcpy_be` function, which is used as memcpy but is guaranteed to copy in big-endian format.