### PR TITLE
Little endianness as per specification

### DIFF
--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -23,8 +23,6 @@
 #define TIGHTLY_PACKED __attribute__((packed, aligned(1)))
 #endif
 
-void memcpy_be(void *dest, const void *src, unsigned long n_bytes);
-
 /** Possible devices from which a packet could originate or be sent to. */
 typedef enum device_address {
     GROUNDSTATION = 0x0, /**< Ground station */

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -23,6 +23,8 @@
 #define TIGHTLY_PACKED __attribute__((packed, aligned(1)))
 #endif
 
+void memcpy_be(void *dest, const void *src, unsigned long n_bytes);
+
 /** Possible devices from which a packet could originate or be sent to. */
 typedef enum device_address {
     GROUNDSTATION = 0x0, /**< Ground station */
@@ -93,8 +95,8 @@ typedef struct block_header {
 
 void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig, const BlockType type,
                        const BlockSubtype subtype, const DeviceAddress dest);
-uint16_t block_header_get_length(const BlockHeader *p);
-void block_header_set_length(BlockHeader *p, const uint16_t length);
+uint16_t block_header_get_length(const BlockHeader *b);
+void block_header_set_length(BlockHeader *b, const uint16_t length);
 
 /** Signal report for the last block that was sent by the block's destination device */
 typedef union signal_report_block {

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,11 @@ int main(int argc, char **argv) {
     }
     callsign = argv[optind];
 
+    BlockHeader b;
+    block_header_init(&b, 4, true, TYPE_DATA, DATA_ALT, GROUNDSTATION);
+    debug_print_bytes(b.bytes, sizeof(b));
+    printf("%u\n", block_header_get_length(&b));
+
     /* Open input stream. */
     FILE *input;
     if (file != NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "packet_types.h"
+#include <assert.h>
 #include <getopt.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/main.c
+++ b/src/main.c
@@ -41,11 +41,6 @@ int main(int argc, char **argv) {
     }
     callsign = argv[optind];
 
-    BlockHeader b;
-    block_header_init(&b, 4, true, TYPE_DATA, DATA_ALT, GROUNDSTATION);
-    debug_print_bytes(b.bytes, sizeof(b));
-    printf("%u\n", block_header_get_length(&b));
-
     /* Open input stream. */
     FILE *input;
     if (file != NULL) {

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -14,17 +14,6 @@
 /** The maximum size of a packet in bytes. */
 static const uint16_t PACKET_MAX_SIZE = 256;
 
-/* Copies memory from source to destination in big endian format.
- * @param dest The destination buffer.
- * @param src The source buffer.
- * @param n_bytes The size of the source buffer in bytes.
- */
-void memcpy_be(void *dest, const void *src, unsigned long n_bytes) {
-    for (unsigned long i = n_bytes; i > 0; i--) {
-        ((uint8_t *)dest)[n_bytes - i] = ((const uint8_t *)src)[i - 1];
-    }
-}
-
 /**
  * Initializes a packet header with the provided information.
  *
@@ -50,6 +39,7 @@ void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t le
         p->bytes[i] = callsign[i];
     }
 
+    // TODO This needs to be little endian
     packet_header_set_length(p, length);
     p->bytes[6] |= (uint8_t)((version & 0x18) >> 3); // First two bits of version right after length
     p->bytes[7] = (uint8_t)((version & 0x07) << 5);  // Last three bits of version at start of byte
@@ -92,6 +82,7 @@ uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6]
 void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig, const BlockType type,
                        const BlockSubtype subtype, const DeviceAddress dest) {
     memset(b, 0, sizeof(BlockHeader)); // Make sure no garbage
+    // TODO This needs to be little endian
     block_header_set_length(b, length);
     b->bytes[0] |= (uint8_t)(has_sig & 0x1) << 2; // One bit, shifted to the end of length
     b->bytes[0] |= (uint8_t)(type & 0x0C) >> 2;   // First two bits at end of byte
@@ -147,10 +138,10 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
  */
 void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
                               const int32_t temperature, const int32_t altitude) {
-    memcpy_be(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy_be(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
-    memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(pressure), &temperature, sizeof(temperature));
-    memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(pressure) + sizeof(temperature), &altitude,
+    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
+    memcpy(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
+    memcpy(b->bytes + sizeof(measurement_time) + sizeof(pressure), &temperature, sizeof(temperature));
+    memcpy(b->bytes + sizeof(measurement_time) + sizeof(pressure) + sizeof(temperature), &altitude,
               sizeof(altitude));
 }
 /**
@@ -166,11 +157,11 @@ void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_t
 void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measurement_time,
                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                  const int16_t z_axis) {
-    memcpy_be(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy_be(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
-    memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
-    memcpy_be(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(y_axis), &z_axis,
+    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
+    memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
+    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
+    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
+    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(y_axis), &z_axis,
               sizeof(z_axis));
 }
 
@@ -187,13 +178,13 @@ void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measure
 void acceleration_data_block_init(AccelerationDataBlock *b, const uint32_t measurement_time,
                                   const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                   const int16_t z_axis) {
-    memcpy_be(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy_be(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
+    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
+    memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
     // One byte of dead space after FSR
-    memcpy_be(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy_be(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis,
+    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
+    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis,
               sizeof(y_axis));
-    memcpy_be(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis),
+    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis),
               &z_axis, sizeof(z_axis));
 }
 


### PR DESCRIPTION
This pull request ensures that all packet types adhere to the packet spec, especially in the case of individual fields being little endian.

This PR has been tested by parsing packet headers and altitude data blocks using the ground station code. I have also tested block headers, but upon inspection, I believe that the ground station code for parsing block headers needs to be revisited.

Closes #35.