### PR TITLE
Update signal report block and inline functions

### DIFF
--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -149,4 +149,41 @@ typedef struct {
 
 bool packet_append_block(Packet *p, const Block b);
 
+/**
+ * Sets the length of the packet the header is associated with.
+ * @param p The packet header to store the length in.
+ * @param length The length of the packet in bytes, not including the packet header itself.
+ */
+extern inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
+    uint8_t encoded_length = ((length + sizeof(PacketHeader)) / 4) - 1; // Include header length, 4 byte increments
+    p->bytes[6] &= ~0xFC;                                               // Clear top 6 bits
+    p->bytes[6] |= (encoded_length & 0x3F) << 2;                        // OR in bottom 6 bits of length, shifted left
+}
+
+/**
+ * Gets the length of the packet header.
+ * @param p The packet header to read the length from.
+ * @return The length of the packet header in bytes, including itself.
+ */
+extern inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
+
+/**
+ * Sets the length of the block the block header is associated with.
+ * @param b The block header to store the length in.
+ * @param length The length of the block in bytes, not including the header itself. Must be a multiple of 4.
+ */
+extern inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
+    uint8_t encoded_length = ((length + sizeof(BlockHeader)) / 4) - 1; // Add header size, 4 byte increments
+    encoded_length &= 0x1F;                                            // Last 5 bits are length
+    b->bytes[0] &= ~0xF8;                                              // Clear the first 5 bits
+    b->bytes[0] |= (encoded_length << 3);                              // Length shifted to start of byte
+}
+
+/**
+ * Gets the length of the block header.
+ * @param p The block header to read the length from.
+ * @return The length of the block header in bytes, including itself.
+ */
+extern inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
+
 #endif // _PACKET_TYPES_H

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -99,24 +99,9 @@ uint16_t block_header_get_length(const BlockHeader *b);
 void block_header_set_length(BlockHeader *b, const uint16_t length);
 
 /** Signal report for the last block that was sent by the block's destination device */
-typedef union signal_report_block {
+typedef struct signal_report_block {
     /** The signal block report accessed as a bytes array */
     uint8_t bytes[4];
-    /** Individually accessible components of the signal report */
-    struct {
-        /** The signal to noise ratio, in units of 1dB/LSB */
-        int8_t snr : 8;
-        /** The recieved signal strength indication, in units of 1dB/LSB */
-        int8_t rssi : 8;
-        /** The index of the radio that sends the request for a report */
-        uint8_t radio : 2;
-        /** Transmit power with which this report was sent in units of 1dB/LSB */
-        int8_t tx_power : 6;
-        /** Reserved bits */
-        uint8_t _dead_space : 7;
-        /** When set, indicates this block is a request, receiver should respond */
-        bool request : 1;
-    } TIGHTLY_PACKED contents;
 } SignalReportBlock;
 
 void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rssi, const uint8_t radio,

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -84,8 +84,6 @@ typedef struct packet_header {
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t length, const uint8_t version,
                         const DeviceAddress source, const uint16_t packet_number);
-uint16_t packet_header_get_length(const PacketHeader *p);
-void packet_header_set_length(PacketHeader *p, uint16_t length);
 
 /** Each block in the radio packet will have a header in this format. */
 typedef struct block_header {
@@ -95,8 +93,6 @@ typedef struct block_header {
 
 void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig, const BlockType type,
                        const BlockSubtype subtype, const DeviceAddress dest);
-uint16_t block_header_get_length(const BlockHeader *b);
-void block_header_set_length(BlockHeader *b, const uint16_t length);
 
 /** Signal report for the last block that was sent by the block's destination device */
 typedef struct signal_report_block {

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -127,13 +127,13 @@ uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] &
  */
 void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rssi, const uint8_t radio,
                         const int8_t tx_power, const bool request) {
-    b->contents.snr = snr;
-    b->contents.rssi = rssi;
-    b->contents.radio = radio;
-    b->contents.tx_power = tx_power;
-    b->contents.request = request;
-    b->contents._dead_space = 0;
+    b->bytes[0] = snr;                         // SNR fills first byte completely
+    b->bytes[1] = rssi;                        // RSSI fills second byte completely
+    b->bytes[2] = (uint8_t)(radio & 0x3) << 6; // Last two bits at start of byte
+    b->bytes[2] |= (uint8_t)(tx_power & 0x3F); // Fill the rest of the six bits
+    b->bytes[3] = (uint8_t)(request & 0x1);    // Set dead space and request indicator
 }
+
 /**
  * Initializes an altitude data block with the provided information.
  * @param b The altitude data to be initialized

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -62,7 +62,7 @@ void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t le
  * @param p The packet header to store the length in.
  * @param length The length of the packet in bytes, not including the packet header itself.
  */
-void packet_header_set_length(PacketHeader *p, const uint16_t length) {
+static inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(PacketHeader)) / 4) - 1; // Include header length, 4 byte increments
     p->bytes[6] &= ~0xFC;                                               // Clear top 6 bits
     p->bytes[6] |= (encoded_length & 0x3F) << 2;                        // OR in bottom 6 bits of length, shifted left
@@ -73,7 +73,7 @@ void packet_header_set_length(PacketHeader *p, const uint16_t length) {
  * @param p The packet header to read the length from.
  * @return The length of the packet header in bytes, including itself.
  */
-uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
+static inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
 
 /**
  * Initializes a block header with the provided information.
@@ -102,7 +102,7 @@ void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig
  * @param b The block header to store the length in.
  * @param length The length of the block in bytes, not including the header itself. Must be a multiple of 4.
  */
-void block_header_set_length(BlockHeader *b, const uint16_t length) {
+static inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(BlockHeader)) / 4) - 1; // Add header size, 4 byte increments
     encoded_length &= 0x1F;                                            // Last 5 bits are length
     b->bytes[0] &= ~0xF8;                                              // Clear the first 5 bits
@@ -114,7 +114,7 @@ void block_header_set_length(BlockHeader *b, const uint16_t length) {
  * @param p The block header to read the length from.
  * @return The length of the block header in bytes, including itself.
  */
-uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
+static inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
 
 /**
  * Initializes a signal report block with the provided information.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -58,24 +58,6 @@ void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t le
 }
 
 /**
- * Sets the length of the packet the header is associated with.
- * @param p The packet header to store the length in.
- * @param length The length of the packet in bytes, not including the packet header itself.
- */
-static inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
-    uint8_t encoded_length = ((length + sizeof(PacketHeader)) / 4) - 1; // Include header length, 4 byte increments
-    p->bytes[6] &= ~0xFC;                                               // Clear top 6 bits
-    p->bytes[6] |= (encoded_length & 0x3F) << 2;                        // OR in bottom 6 bits of length, shifted left
-}
-
-/**
- * Gets the length of the packet header.
- * @param p The packet header to read the length from.
- * @return The length of the packet header in bytes, including itself.
- */
-static inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
-
-/**
  * Initializes a block header with the provided information.
  *
  * @param b The block header to be initialized
@@ -96,25 +78,6 @@ void block_header_init(BlockHeader *b, const uint16_t length, const bool has_sig
     b->bytes[2] = (uint8_t)(dest & 0xF) << 4; // Destination in top of byte
     b->bytes[3] = 0;                          // Dead space
 }
-
-/**
- * Sets the length of the block the block header is associated with.
- * @param b The block header to store the length in.
- * @param length The length of the block in bytes, not including the header itself. Must be a multiple of 4.
- */
-static inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
-    uint8_t encoded_length = ((length + sizeof(BlockHeader)) / 4) - 1; // Add header size, 4 byte increments
-    encoded_length &= 0x1F;                                            // Last 5 bits are length
-    b->bytes[0] &= ~0xF8;                                              // Clear the first 5 bits
-    b->bytes[0] |= (encoded_length << 3);                              // Length shifted to start of byte
-}
-
-/**
- * Gets the length of the block header.
- * @param p The block header to read the length from.
- * @return The length of the block header in bytes, including itself.
- */
-static inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
 
 /**
  * Initializes a signal report block with the provided information.


### PR DESCRIPTION
The signal report block has been modified to use raw byte arrays like the rest of the blocks. The get and set functions have also been changed to be inline. If we ever encounter problems trying to use inline functions as regular functions, we may have to add a library file with regular definitions. 

Closes #22.