### PR TITLE
Parse sensor input

### DIFF
--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -67,14 +67,13 @@ typedef enum command_block_type {
 /** Possible sub-types of data blocks that can be sent. */
 typedef enum data_block_type {
     DATA_DBG_MSG = 0x0,     /**< Debug message */
-    DATA_STATUS = 0x1,      /**< Debug status */
-    DATA_ALT = 0x2,         /**< Altitude data */
-    DATA_TEMP = 0x3,        /**< Temperature data */
-    DATA_PRESSURE = 0x4,    /**< Pressure data */
-    DATA_ACCEL = 0x5,       /**< Acceleration data */
-    DATA_ANGULAR_VEL = 0x6, /**< Angular velocity data */
-    DATA_GNSS_LOC = 0x7,    /**< GNSS location data */
-    DATA_GNSS_META = 0x8,   /**< GNSS metadata */
+    DATA_ALT = 0x1,         /**< Altitude data */
+    DATA_TEMP = 0x2,        /**< Temperature data */
+    DATA_PRESSURE = 0x3,    /**< Pressure data */
+    DATA_ACCEL = 0x4,       /**< Acceleration data */
+    DATA_ANGULAR_VEL = 0x5, /**< Angular velocity data */
+    DATA_GNSS_LOC = 0x6,    /**< GNSS location data */
+    DATA_GNSS_META = 0x7,   /**< GNSS metadata */
 } DataBlockType;
 
 /** Any block sub-type from DataBlockType, CtrlBlockType or CmdBlockType. */
@@ -137,18 +136,16 @@ typedef struct {
     uint8_t bytes[12];
 } AngularVelocityDB;
 
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time,
-                                 const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
-                                 const int16_t z_axis);
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+                              const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 /** A data block containing information about acceleration. */
 typedef struct acceleration_data_block {
     uint8_t bytes[12];
 } AccelerationDB;
 
-void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time,
-                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
-                                  const int16_t z_axis);
+void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+                          const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 typedef struct telemetry_request_block {
     /** The telemetry request block accessed as a bytes array. */

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -15,6 +15,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/** The maximum size a packet can be in bytes. */
+#define PACKET_MAX_SIZE 256
+
+/** The maximum size a block can be in bytes. */
+#define BLOCK_MAX_SIZE 128
+
 // Don't confuse Doxygen documenting with the attribute macro
 #if __DOXYGEN__
 #define TIGHTLY_PACKED
@@ -154,6 +160,8 @@ typedef struct {
     PacketHeader header;
     /** Packet contents in blocks, up to 256 bytes long. */
     Block *blocks;
+    /** The number of blocks in this packet. */
+    uint8_t block_count;
 } TIGHTLY_PACKED Packet;
 
 bool packet_append_block(Packet *p, const Block b);

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -111,42 +111,42 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
 typedef struct {
     /** The altitude data block accessed as a bytes array */
     uint8_t bytes[8];
-} AltitudeDataBlock;
+} AltitudeDB;
 
-void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t altitude);
+void altitude_db_init(AltitudeDB *b, const uint32_t measurement_time, const int32_t altitude);
 
 /** A data block containing information about temperature. */
 typedef struct {
     /** The temperature data block can be accessed as a bytes array. */
     uint8_t bytes[8];
-} TemperatureDataBlock;
+} TemperatureDB;
 
-void temperature_data_block_init(TemperatureDataBlock *b, const uint32_t measurement_time, const int32_t temperature);
+void temperature_db_init(TemperatureDB *b, const uint32_t measurement_time, const int32_t temperature);
 
 /** A data block containing information about pressure. */
 typedef struct {
     /** The pressure data block can be accessed as a bytes array. */
     uint8_t bytes[8];
-} PressureDataBlock;
+} PressureDB;
 
-void pressure_data_block_init(PressureDataBlock *b, const uint32_t measurement_time, const int32_t pressure);
+void pressure_db_init(PressureDB *b, const uint32_t measurement_time, const int32_t pressure);
 
 /** A data block containing information about angular velocity. */
 typedef struct {
     /** The angular velocity block accessed as a bytes array */
     uint8_t bytes[12];
-} AngularVelocityBlock;
+} AngularVelocityDB;
 
-void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measurement_time,
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time,
                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                  const int16_t z_axis);
 
 /** A data block containing information about acceleration. */
 typedef struct acceleration_data_block {
     uint8_t bytes[12];
-} AccelerationDataBlock;
+} AccelerationDB;
 
-void acceleration_data_block_init(AccelerationDataBlock *b, const uint32_t measurement_time,
+void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time,
                                   const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                   const int16_t z_axis);
 

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 /** The maximum size a packet can be in bytes. */
 #define PACKET_MAX_SIZE 256
@@ -165,6 +166,7 @@ typedef struct {
 } TIGHTLY_PACKED Packet;
 
 bool packet_append_block(Packet *p, const Block b);
+void packet_print_hex(FILE *stream, Packet *packet);
 
 /**
  * Sets the length of the packet the header is associated with.

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -132,7 +132,7 @@ void acceleration_data_block_init(AccelerationDataBlock *b, const uint32_t measu
                                   const int16_t z_axis);
 
 typedef struct telemetry_request_block {
-    /**The telemetry request block accessed as a bytes array. */
+    /** The telemetry request block accessed as a bytes array. */
     uint8_t bytes[4];
 } TelemetryRequestBlock;
 
@@ -163,7 +163,7 @@ bool packet_append_block(Packet *p, const Block b);
  * @param p The packet header to store the length in.
  * @param length The length of the packet in bytes, not including the packet header itself.
  */
-extern inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
+inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(PacketHeader)) / 4) - 1; // Include header length, 4 byte increments
     p->bytes[6] &= ~0xFC;                                               // Clear top 6 bits
     p->bytes[6] |= (encoded_length & 0x3F) << 2;                        // OR in bottom 6 bits of length, shifted left
@@ -174,14 +174,14 @@ extern inline void packet_header_set_length(PacketHeader *p, const uint16_t leng
  * @param p The packet header to read the length from.
  * @return The length of the packet header in bytes, including itself.
  */
-extern inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
+inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
 
 /**
  * Sets the length of the block the block header is associated with.
  * @param b The block header to store the length in.
  * @param length The length of the block in bytes, not including the header itself. Must be a multiple of 4.
  */
-extern inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
+inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(BlockHeader)) / 4) - 1; // Add header size, 4 byte increments
     encoded_length &= 0x1F;                                            // Last 5 bits are length
     b->bytes[0] &= ~0xF8;                                              // Clear the first 5 bits
@@ -193,6 +193,6 @@ extern inline void block_header_set_length(BlockHeader *b, const uint16_t length
  * @param p The block header to read the length from.
  * @return The length of the block header in bytes, including itself.
  */
-extern inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
+inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
 
 #endif // _PACKET_TYPES_H

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -182,7 +182,7 @@ void packet_print_hex(FILE *stream, Packet *packet);
  * @param p The packet header to store the length in.
  * @param length The length of the packet in bytes, not including the packet header itself.
  */
-inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
+static inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(PacketHeader)) / 4) - 1; // Include header length, 4 byte increments
     p->bytes[6] &= ~0xFC;                                               // Clear top 6 bits
     p->bytes[6] |= (encoded_length & 0x3F) << 2;                        // OR in bottom 6 bits of length, shifted left
@@ -193,14 +193,14 @@ inline void packet_header_set_length(PacketHeader *p, const uint16_t length) {
  * @param p The packet header to read the length from.
  * @return The length of the packet header in bytes, including itself.
  */
-inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
+static inline uint16_t packet_header_get_length(const PacketHeader *p) { return (((p->bytes[6] & 0xFC) >> 2) + 1) * 4; }
 
 /**
  * Sets the length of the block the block header is associated with.
  * @param b The block header to store the length in.
  * @param length The length of the block in bytes, not including the header itself. Must be a multiple of 4.
  */
-inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
+static inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
     uint8_t encoded_length = ((length + sizeof(BlockHeader)) / 4) - 1; // Add header size, 4 byte increments
     encoded_length &= 0x1F;                                            // Last 5 bits are length
     b->bytes[0] &= ~0xF8;                                              // Clear the first 5 bits
@@ -212,6 +212,6 @@ inline void block_header_set_length(BlockHeader *b, const uint16_t length) {
  * @param p The block header to read the length from.
  * @return The length of the block header in bytes, including itself.
  */
-inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
+static inline uint16_t block_header_get_length(const BlockHeader *b) { return (((b->bytes[0] & 0xF8) >> 3) + 1) * 4; }
 
 #endif // _PACKET_TYPES_H

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -66,18 +66,15 @@ typedef enum command_block_type {
 
 /** Possible sub-types of data blocks that can be sent. */
 typedef enum data_block_type {
-    DATA_DBG_MSG = 0x0,          /**< Debug message */
-    DATA_STATUS = 0x1,           /**< Debug status */
-    DATA_STARTUP_MSG = 0x2,      /**< Startup message */
-    DATA_ALT = 0x3,              /**< Altitude data */
-    DATA_ACCEL = 0x3,            /**< Acceleration data */
-    DATA_ANGULAR_VEL = 0x4,      /**< Angular velocity data */
-    DATA_GNSS_LOC = 0x5,         /**< GNSS location data */
-    DATA_GNSS_META = 0x6,        /**< GNSS metadata */
-    DATA_PWR_INFO = 0x7,         /**< Power info */
-    DATA_TEMP = 0x8,             /**< Temperature data */
-    DATA_MPU9250_IMU = 0x9,      /**< MPU9250-IMU data */
-    DATA_KX134_1211_ACCEL = 0xA, /**< KX134-1211 accelerometer data */
+    DATA_DBG_MSG = 0x0,     /**< Debug message */
+    DATA_STATUS = 0x1,      /**< Debug status */
+    DATA_ALT = 0x2,         /**< Altitude data */
+    DATA_TEMP = 0x3,        /**< Temperature data */
+    DATA_PRESSURE = 0x4,    /**< Pressure data */
+    DATA_ACCEL = 0x5,       /**< Acceleration data */
+    DATA_ANGULAR_VEL = 0x6, /**< Angular velocity data */
+    DATA_GNSS_LOC = 0x7,    /**< GNSS location data */
+    DATA_GNSS_META = 0x8,   /**< GNSS metadata */
 } DataBlockType;
 
 /** Any block sub-type from DataBlockType, CtrlBlockType or CmdBlockType. */
@@ -111,16 +108,31 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
                         const int8_t tx_power, const bool request);
 
 /** A data block containing information about altitude. */
-typedef struct altitude_data_block {
+typedef struct {
     /** The altitude data block accessed as a bytes array */
-    uint8_t bytes[16];
+    uint8_t bytes[8];
 } AltitudeDataBlock;
 
-void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
-                              const int32_t temperature, const int32_t altitude);
+void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t altitude);
+
+/** A data block containing information about temperature. */
+typedef struct {
+    /** The temperature data block can be accessed as a bytes array. */
+    uint8_t bytes[8];
+} TemperatureDataBlock;
+
+void temperature_data_block_init(TemperatureDataBlock *b, const uint32_t measurement_time, const int32_t temperature);
+
+/** A data block containing information about pressure. */
+typedef struct {
+    /** The pressure data block can be accessed as a bytes array. */
+    uint8_t bytes[8];
+} PressureDataBlock;
+
+void pressure_data_block_init(PressureDataBlock *b, const uint32_t measurement_time, const int32_t pressure);
 
 /** A data block containing information about angular velocity. */
-typedef struct angular_velocity_block {
+typedef struct {
     /** The angular velocity block accessed as a bytes array */
     uint8_t bytes[12];
 } AngularVelocityBlock;

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,10 @@ const char *DTYPES[] = {
 
 /** The size of the buffer for reading sensor data input. */
 #define BUFFER_SIZE 150
+/** The maximum number of blocks that can be added to a packet before it is sent. */
+#define BLOCK_LIMIT 3
+/** The version of the packet encoding being used. */
+#define VERSION 1
 
 /** Static variable to store the user HAM radio call sign. */
 static char *callsign = NULL;
@@ -27,8 +31,10 @@ static char *callsign = NULL;
 static char *file = NULL;
 /** Static buffer for reading input. */
 static char buffer[BUFFER_SIZE] = {0};
+/** Static buffer for storing the contents of packets as they are being created from input. */
+static uint8_t block_contents[PACKET_MAX_SIZE];
 
-void debug_print_bytes(uint8_t *bytes, size_t n_bytes);
+void debug_print_bytes(uint8_t *bytes, size_t n_bytes, bool newline);
 Dtype dtype_from_str(const char *str);
 
 int main(int argc, char **argv) {
@@ -71,34 +77,68 @@ int main(int argc, char **argv) {
         input = stdin;
     }
 
-    /* Read input data. WARNING: No error handling for when text read is longer than buffer. */
-    while (fgets(buffer, BUFFER_SIZE, input) != NULL) {
-        char *dtype_str = strtok(buffer, ":");
-        Dtype dtype = dtype_from_str(dtype_str);
-        switch (dtype) {
-        case DTYPE_TIME:
-            printf("Time: %d\n", atoi(strtok(NULL, ":")));
-            break;
-        case DTYPE_TEMPERATURE:
-            printf("Temp: %s\n", strtok(NULL, ":"));
-            break;
-        case DTYPE_PRESSURE:
-            printf("Pres: %s\n", strtok(NULL, ":"));
-            break;
-        default:
-            fprintf(stderr, "Unknown input data type: %s\n", dtype_str);
-            continue;
-        }
-    }
+    uint64_t pkt_count = 0;
+    Block blocks[BLOCK_LIMIT]; // Memory for storing blocks in packet
+    Block block;               // Memory for storing new block headers
 
+    for (;;) {
+        // Construct packet out of BLOCK_LIMIT blocks
+        Packet packet;
+        packet.block_count = 0;
+        packet.blocks = blocks;
+        packet_header_init(&packet.header, callsign, 0, VERSION, ROCKET, pkt_count);
+
+        uint8_t *contents_ptr = &block_contents[0];
+        while (packet.block_count < BLOCK_LIMIT) {
+
+            /* Read input data. WARNING: No error handling for when text read is longer than buffer. */
+            if (fgets(buffer, BUFFER_SIZE, input) == NULL) return EXIT_SUCCESS; // No more data
+
+            // Decide what contents to add to the block
+            char *dtype_str = strtok(buffer, ":");
+            Dtype dtype = dtype_from_str(dtype_str);
+            switch (dtype) {
+            case DTYPE_TIME:
+                break;
+            case DTYPE_TEMPERATURE:
+                block_header_init(&block.header, 0, false, TYPE_DATA, DATA_ALT, GROUNDSTATION);
+                uint32_t temp = strtoul(strtok(NULL, ":"), NULL, 10);
+                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 0, 0, temp, 0);
+                block.contents = contents_ptr;
+                contents_ptr += sizeof(AltitudeDataBlock);
+                break;
+            case DTYPE_PRESSURE:
+                break;
+            default:
+                fprintf(stderr, "Unknown input data type: %s\n", dtype_str);
+                continue; // Skip to next iteration without storing block
+            }
+
+            // Copy the newly made block into the packet and handle insufficient space
+            if (!packet_append_block(&packet, block)) {
+                fprintf(stderr, "Packet size exceeded before block limit exceeded! Sending packet.\n");
+                break;
+            }
+        }
+        pkt_count++;
+
+        // Send the packet over stdout
+        debug_print_bytes(packet.header.bytes, sizeof(packet.header.bytes), false);
+        for (uint8_t i = 0; i < packet.block_count; i++) {
+            debug_print_bytes(packet.blocks[i].header.bytes, sizeof(packet.blocks[i].header.bytes), false);
+            uint16_t content_len = block_header_get_length(&packet.blocks[i].header) - sizeof(packet.blocks[i].header);
+            debug_print_bytes(packet.blocks[i].contents, content_len, false);
+        }
+        putchar('\n');
+    }
     return EXIT_SUCCESS;
 }
 
-void debug_print_bytes(uint8_t *bytes, size_t n_bytes) {
+void debug_print_bytes(uint8_t *bytes, size_t n_bytes, bool newline) {
     for (size_t i = 0; i < n_bytes; i++) {
         printf("%02x ", bytes[i]);
     }
-    putchar('\n');
+    if (newline) putchar('\n');
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -122,15 +122,7 @@ int main(int argc, char **argv) {
             }
         }
         pkt_count++;
-
-        // Send the packet over stdout
-        debug_print_bytes(packet.header.bytes, sizeof(packet.header.bytes), false);
-        for (uint8_t i = 0; i < packet.block_count; i++) {
-            debug_print_bytes(packet.blocks[i].header.bytes, sizeof(packet.blocks[i].header.bytes), false);
-            uint16_t content_len = block_header_get_length(&packet.blocks[i].header) - sizeof(packet.blocks[i].header);
-            debug_print_bytes(packet.blocks[i].contents, content_len, false);
-        }
-        putchar('\n');
+        packet_print_hex(stdout, &packet);
     }
     return EXIT_SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@
 typedef enum {
     DTYPE_TEMPERATURE = 0, /**< Temperature */
     DTYPE_TIME = 1,        /**< Time */
-    DTYPE_PRESSURE = 2,    /** Pressure */
+    DTYPE_PRESSURE = 2,    /**< Pressure */
     DTYPE_DNE = 3,         /**< Data type does not exist */
 } Dtype;
 
@@ -38,7 +38,7 @@ static Block blocks[BLOCK_LIMIT];
 /** Static buffer for storing the contents of packets as they are being created from input. */
 static uint8_t block_contents[PACKET_MAX_SIZE];
 /** The current position in the block_contents array at which to allocate new contents. */
-uint8_t *contents_pos = &block_contents[0];
+static uint8_t *contents_pos = &block_contents[0];
 /** Memory for storing new block headers as they are parsed. */
 static Block block;
 /** Packet count tracker for encoding packets number. */
@@ -102,12 +102,13 @@ int main(int argc, char **argv) {
             /* Read input data. WARNING: No error handling for when text read is longer than buffer. */
             if (fgets(buffer, BUFFER_SIZE, input) == NULL) {
                 no_input = true; // No more data
-                break; // Send the partially constructed packet before exiting
+                break;           // Send the partially constructed packet before exiting
             }
 
             // Decide what contents to add to the block
             char *dtype_str = strtok(buffer, ":");
             Dtype dtype = dtype_from_str(dtype_str);
+
             switch (dtype) {
             case DTYPE_TIME:
                 // Update with most recent time measurement to use as measurement time for other packets

--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,8 @@ int main(int argc, char **argv) {
         input = stdin;
     }
 
-    for (;;) {
+    bool no_input = false;
+    while (!no_input) {
         // Construct packet out of BLOCK_LIMIT blocks
         packet.block_count = 0;
         packet_header_init(&packet.header, callsign, 0, VERSION, ROCKET, pkt_count);
@@ -99,7 +100,10 @@ int main(int argc, char **argv) {
         while (packet.block_count < BLOCK_LIMIT) {
 
             /* Read input data. WARNING: No error handling for when text read is longer than buffer. */
-            if (fgets(buffer, BUFFER_SIZE, input) == NULL) return EXIT_SUCCESS; // No more data
+            if (fgets(buffer, BUFFER_SIZE, input) == NULL) {
+                no_input = true; // No more data
+                break; // Send the partially constructed packet before exiting
+            }
 
             // Decide what contents to add to the block
             char *dtype_str = strtok(buffer, ":");

--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,8 @@ int main(int argc, char **argv) {
             case DTYPE_TEMPERATURE:
                 block_header_init(&block.header, 0, false, TYPE_DATA, DATA_ALT, GROUNDSTATION);
                 uint32_t temp = strtoul(strtok(NULL, ":"), NULL, 10);
-                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 0, 0, temp, 0);
+                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 1, 2, temp, 3);
+                block_header_set_length(&block.header, sizeof(AltitudeDataBlock));
                 block.contents = contents_ptr;
                 contents_ptr += sizeof(AltitudeDataBlock);
                 break;

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 #include "packet_types.h"
-#include <assert.h>
 #include <getopt.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -101,14 +100,19 @@ int main(int argc, char **argv) {
             case DTYPE_TIME:
                 break;
             case DTYPE_TEMPERATURE:
-                block_header_init(&block.header, 0, false, TYPE_DATA, DATA_ALT, GROUNDSTATION);
-                uint32_t temp = 1000 * strtod(strtok(NULL, ":"), NULL);
-                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 0, 0, temp, 0);
-                block_header_set_length(&block.header, sizeof(AltitudeDataBlock));
+                block_header_init(&block.header, 0, false, TYPE_DATA, DATA_TEMP, GROUNDSTATION);
+                temperature_data_block_init((TemperatureDataBlock *)contents_ptr, 0,
+                                            1000 * strtod(strtok(NULL, ":"), NULL));
+                block_header_set_length(&block.header, sizeof(TemperatureDataBlock));
                 block.contents = contents_ptr;
-                contents_ptr += sizeof(AltitudeDataBlock);
+                contents_ptr += sizeof(TemperatureDataBlock);
                 break;
             case DTYPE_PRESSURE:
+                block_header_init(&block.header, 0, false, TYPE_DATA, DATA_PRESSURE, GROUNDSTATION);
+                pressure_data_block_init((PressureDataBlock *)contents_ptr, 0, 1000 * strtod(strtok(NULL, ":"), NULL));
+                block_header_set_length(&block.header, sizeof(PressureDataBlock));
+                block.contents = contents_ptr;
+                contents_ptr += sizeof(PressureDataBlock);
                 break;
             default:
                 fprintf(stderr, "Unknown input data type: %s\n", dtype_str);

--- a/src/main.c
+++ b/src/main.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
         input = stdin;
     }
 
-    uint64_t pkt_count = 0;
+    uint16_t pkt_count = 0;
     Block blocks[BLOCK_LIMIT]; // Memory for storing blocks in packet
     Block block;               // Memory for storing new block headers
 
@@ -102,8 +102,8 @@ int main(int argc, char **argv) {
                 break;
             case DTYPE_TEMPERATURE:
                 block_header_init(&block.header, 0, false, TYPE_DATA, DATA_ALT, GROUNDSTATION);
-                uint32_t temp = strtoul(strtok(NULL, ":"), NULL, 10);
-                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 1, 2, temp, 3);
+                uint32_t temp = 1000 * strtod(strtok(NULL, ":"), NULL);
+                altitude_data_block_init((AltitudeDataBlock *)contents_ptr, 0, 0, temp, 0);
                 block_header_set_length(&block.header, sizeof(AltitudeDataBlock));
                 block.contents = contents_ptr;
                 contents_ptr += sizeof(AltitudeDataBlock);

--- a/src/main.c
+++ b/src/main.c
@@ -90,6 +90,7 @@ int main(int argc, char **argv) {
         packet_header_init(&packet.header, callsign, 0, VERSION, ROCKET, pkt_count);
 
         uint8_t *contents_ptr = &block_contents[0];
+        uint32_t last_time = 0;
         while (packet.block_count < BLOCK_LIMIT) {
 
             /* Read input data. WARNING: No error handling for when text read is longer than buffer. */
@@ -100,17 +101,19 @@ int main(int argc, char **argv) {
             Dtype dtype = dtype_from_str(dtype_str);
             switch (dtype) {
             case DTYPE_TIME:
+                // Update with most recent time measurement to use as measurement time for other packets
+                last_time = strtoul(strtok(NULL, ":"), NULL, 10);
                 break;
             case DTYPE_TEMPERATURE:
                 block_header_init(&block.header, 0, false, TYPE_DATA, DATA_TEMP, GROUNDSTATION);
-                temperature_db_init((TemperatureDB *)contents_ptr, 0, 1000 * strtod(strtok(NULL, ":"), NULL));
+                temperature_db_init((TemperatureDB *)contents_ptr, last_time, 1000 * strtod(strtok(NULL, ":"), NULL));
                 block_header_set_length(&block.header, sizeof(TemperatureDB));
                 block.contents = contents_ptr;
                 contents_ptr += sizeof(TemperatureDB);
                 break;
             case DTYPE_PRESSURE:
                 block_header_init(&block.header, 0, false, TYPE_DATA, DATA_PRESSURE, GROUNDSTATION);
-                pressure_db_init((PressureDB *)contents_ptr, 0, 1000 * strtod(strtok(NULL, ":"), NULL));
+                pressure_db_init((PressureDB *)contents_ptr, last_time, 1000 * strtod(strtok(NULL, ":"), NULL));
                 block_header_set_length(&block.header, sizeof(PressureDB));
                 block.contents = contents_ptr;
                 contents_ptr += sizeof(PressureDB);

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -100,7 +100,7 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
  * @param measurement_time The mission time at the taking of the measurement
  * @param altitude The calculated altitude in units of 1 mm/LSB.
  */
-void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t altitude) {
+void altitude_db_init(AltitudeDB *b, const uint32_t measurement_time, const int32_t altitude) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &altitude, sizeof(altitude));
 }
@@ -111,7 +111,7 @@ void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_t
  * @param measurement_time The mission time at the taking of the measurement
  * @param temperature The calculated temperature in units of millidegrees Celsius.
  */
-void temperature_data_block_init(TemperatureDataBlock *b, const uint32_t measurement_time, const int32_t temperature) {
+void temperature_db_init(TemperatureDB *b, const uint32_t measurement_time, const int32_t temperature) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &temperature, sizeof(temperature));
 }
@@ -122,7 +122,7 @@ void temperature_data_block_init(TemperatureDataBlock *b, const uint32_t measure
  * @param measurement_time The mission time at the taking of the measurement
  * @param pressure The calculated pressure in units of Pascals.
  */
-void pressure_data_block_init(PressureDataBlock *b, const uint32_t measurement_time, const int32_t pressure) {
+void pressure_db_init(PressureDB *b, const uint32_t measurement_time, const int32_t pressure) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
 }
@@ -137,7 +137,7 @@ void pressure_data_block_init(PressureDataBlock *b, const uint32_t measurement_t
  * @param y_axis The angular velocity measurement for the y axis.
  * @param z_axis The angular velocity measurement for the z axis.
  */
-void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measurement_time,
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time,
                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                  const int16_t z_axis) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
@@ -158,7 +158,7 @@ void angular_velocity_block_init(AngularVelocityBlock *b, const uint32_t measure
  * @param y_axis The acceleration measurement for the y axis.
  * @param z_axis The acceleration measurement for the z axis.
  * */
-void acceleration_data_block_init(AccelerationDataBlock *b, const uint32_t measurement_time,
+void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time,
                                   const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
                                   const int16_t z_axis) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -181,6 +181,7 @@ void telemetry_request_block_init(TelemetryRequestBlock *b, const uint8_t data_s
     b->bytes[3] = data_subtype_4 << 2;
     b->bytes[3] |= used_4 && 0x01;
 }
+
 /**
  * Appends a block to a packet. WARNING: This function assumes that there is sufficient memory in the packet to store
  * the block.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 /* Copies memory from source to destination in big endian format.
@@ -216,4 +217,29 @@ bool packet_append_block(Packet *p, const Block b) {
     packet_header_set_length(&p->header, p_len - sizeof(PacketHeader) + b_len);
     p->block_count++;
     return true;
+}
+
+#define write_bytes(stream, bytes)                                                                                     \
+    for (size_t hjkl = 0; hjkl < sizeof(bytes); hjkl++) {                                                              \
+        fprintf(stream, "%02x", bytes[hjkl]);                                                                          \
+    }
+
+#define write_bytes_sized(stream, bytes, size)                                                                         \
+    for (size_t hjkl = 0; hjkl < size; hjkl++) {                                                                       \
+        fprintf(stream, "%02x", bytes[hjkl]);                                                                          \
+    }
+
+/**
+ * Prints a packet to the output stream in hexadecimal representation.
+ * @param stream The output stream to which the packet should be printed.
+ * @param packet The packet to be printed.
+ */
+void packet_print_hex(FILE *stream, Packet *packet) {
+    write_bytes(stream, packet->header.bytes);
+    for (uint8_t i = 0; i < packet->block_count; i++) {
+        write_bytes(stream, packet->blocks[i].header.bytes);
+        uint16_t content_len = block_header_get_length(&packet->blocks[i].header) - sizeof(packet->blocks[i].header);
+        write_bytes_sized(stream, packet->blocks[i].contents, content_len);
+    }
+    putchar('\n');
 }

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -5,7 +5,6 @@
  * Packet types should be created using their initialization functions.
  */
 #include "packet_types.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -99,17 +98,35 @@ void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rss
  * Initializes an altitude data block with the provided information.
  * @param b The altitude data to be initialized
  * @param measurement_time The mission time at the taking of the measurement
- * @param pressure The measured pressure in terms of Pascals.
- * @param temperature The measured temperature in units of 1 millidegree Celsius/LSB.
  * @param altitude The calculated altitude in units of 1 mm/LSB.
  */
-void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t pressure,
-                              const int32_t temperature, const int32_t altitude) {
+void altitude_data_block_init(AltitudeDataBlock *b, const uint32_t measurement_time, const int32_t altitude) {
+    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
+    memcpy(b->bytes + sizeof(measurement_time), &altitude, sizeof(altitude));
+}
+
+/**
+ * Initializes a temperature data block with the provided information.
+ * @param b The temperature data block to be initialized.
+ * @param measurement_time The mission time at the taking of the measurement
+ * @param temperature The calculated temperature in units of millidegrees Celsius.
+ */
+void temperature_data_block_init(TemperatureDataBlock *b, const uint32_t measurement_time, const int32_t temperature) {
+    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
+    memcpy(b->bytes + sizeof(measurement_time), &temperature, sizeof(temperature));
+}
+
+/**
+ * Initializes a temperature data block with the provided information.
+ * @param b The temperature data block to be initialized.
+ * @param measurement_time The mission time at the taking of the measurement
+ * @param pressure The calculated pressure in units of Pascals.
+ */
+void pressure_data_block_init(PressureDataBlock *b, const uint32_t measurement_time, const int32_t pressure) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
-    memcpy(b->bytes + sizeof(measurement_time) + sizeof(pressure), &temperature, sizeof(temperature));
-    memcpy(b->bytes + sizeof(measurement_time) + sizeof(pressure) + sizeof(temperature), &altitude, sizeof(altitude));
 }
+
 /**
  * Initializes an angular velocity block with the provided information.
  * @param b The angular velocity block to be initialized.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -10,9 +10,6 @@
 #include <stdint.h>
 #include <string.h>
 
-/** The maximum size of a packet in bytes. */
-static const uint16_t PACKET_MAX_SIZE = 256;
-
 /* Copies memory from source to destination in big endian format.
  * @param dest The destination buffer.
  * @param src The source buffer.
@@ -201,6 +198,7 @@ bool packet_append_block(Packet *p, const Block b) {
     if (p_len == sizeof(PacketHeader)) {
         p->blocks[0] = b;
         packet_header_set_length(&p->header, b_len); // The packet is now the length of the first block
+        p->block_count++;
         return true;
     }
 
@@ -216,5 +214,6 @@ bool packet_append_block(Packet *p, const Block b) {
     p->blocks[i] = b; // Add block at correct spot
     // Packet length is now equal to its previous length + the new block
     packet_header_set_length(&p->header, p_len - sizeof(PacketHeader) + b_len);
+    p->block_count++;
     return true;
 }

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -137,9 +137,8 @@ void pressure_db_init(PressureDB *b, const uint32_t measurement_time, const int3
  * @param y_axis The angular velocity measurement for the y axis.
  * @param z_axis The angular velocity measurement for the z axis.
  */
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time,
-                                 const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
-                                 const int16_t z_axis) {
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+                              const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
     memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
@@ -158,9 +157,8 @@ void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_t
  * @param y_axis The acceleration measurement for the y axis.
  * @param z_axis The acceleration measurement for the z axis.
  * */
-void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time,
-                                  const int8_t full_scale_range, const int16_t x_axis, const int16_t y_axis,
-                                  const int16_t z_axis) {
+void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+                          const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
     memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
     memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
     // One byte of dead space after FSR


### PR DESCRIPTION
This pull request implements parsing of sensor data printed by fetcher through stdin. It can successfully parse all of the data currently outputted by fetcher and package it into radio packet format (recently modified to remove deprecated and unused data blocks).

### Shortcomings
- The parsing logic currently has no regard for the units printed by fetcher; it assumes that temperature is in degrees Celsius for instance.
- The parsing logic is currently unable to bundle information together for data blocks that have more than one entry (i.e. latitude and longitude in one block). This will need to be fixed in the near future.