### PR TITLE
Implemented packets as pure C structs

### DIFF
--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -114,8 +114,10 @@ void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const in
 
 /** A data block containing information about humidity. */
 typedef struct {
-    /** The humidity data block can be accessed as a bytes array. */
-    uint8_t bytes[8];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Relative humidity in ten thousandths of a percent. */
+    uint32_t humidity;
 } HumidityDB;
 
 void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity);

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -94,19 +94,23 @@ void block_header_init(BlockHeader *b, const uint16_t length, const BlockType ty
 
 /** A data block containing information about altitude. */
 typedef struct {
-    /** The altitude data block accessed as a bytes array */
-    uint8_t bytes[8];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Altitude in units of millimetres above/below the launch height. */
+    int32_t altitude;
 } AltitudeDB;
 
-void altitude_db_init(AltitudeDB *b, const uint32_t measurement_time, const int32_t altitude);
+void altitude_db_init(AltitudeDB *b, const uint32_t mission_time, const int32_t altitude);
 
 /** A data block containing information about temperature. */
 typedef struct {
-    /** The temperature data block can be accessed as a bytes array. */
-    uint8_t bytes[8];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Temperature in millidegrees Celsius. */
+    int32_t temperature;
 } TemperatureDB;
 
-void temperature_db_init(TemperatureDB *b, const uint32_t measurement_time, const int32_t temperature);
+void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const int32_t temperature);
 
 /** A data block containing information about humidity. */
 typedef struct {
@@ -114,7 +118,7 @@ typedef struct {
     uint8_t bytes[8];
 } HumidityDB;
 
-void humidity_db_init(HumidityDB *b, const uint32_t measurement_time, const uint32_t humidity);
+void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity);
 
 /** A data block containing information about pressure. */
 typedef struct {
@@ -122,7 +126,7 @@ typedef struct {
     uint8_t bytes[8];
 } PressureDB;
 
-void pressure_db_init(PressureDB *b, const uint32_t measurement_time, const int32_t pressure);
+void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure);
 
 /** A data block containing information about angular velocity. */
 typedef struct {
@@ -130,7 +134,7 @@ typedef struct {
     uint8_t bytes[12];
 } AngularVelocityDB;
 
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int8_t full_scale_range,
                               const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 /** A data block containing information about acceleration. */
@@ -138,7 +142,7 @@ typedef struct acceleration_data_block {
     uint8_t bytes[12];
 } AccelerationDB;
 
-void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int8_t full_scale_range,
                           const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 typedef struct telemetry_request_block {

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -145,15 +145,6 @@ typedef struct acceleration_data_block {
 void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int8_t full_scale_range,
                           const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
-typedef struct telemetry_request_block {
-    /** The telemetry request block accessed as a bytes array. */
-    uint8_t bytes[4];
-} TelemetryRequestBlock;
-
-void telemetry_request_block_init(TelemetryRequestBlock *b, const uint8_t data_subtype_1, const uint8_t used_1,
-                                  const uint8_t data_subtype_2, const uint8_t used_2, const uint8_t data_subtype_3,
-                                  const uint8_t used_3, const uint8_t data_subtype_4, const uint8_t used_4);
-
 /** A data block containing location information provided by a GNSS sensor */
 typedef struct gnss_location_data_block {
     uint8_t bytes[32];

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -134,20 +134,37 @@ void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t 
 
 /** A data block containing information about angular velocity. */
 typedef struct {
-    /** The angular velocity block accessed as a bytes array */
-    uint8_t bytes[12];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Angular velocity in the x-axis measured in tenths of degrees per second. */
+    int16_t x;
+    /** Angular velocity in the y-axis measured in tenths of degrees per second. */
+    int16_t y;
+    /** Angular velocity in the z-axis measured in tenths of degrees per second. */
+    int16_t z;
+    /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
+    int16_t _padding;
 } AngularVelocityDB;
 
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int8_t full_scale_range,
-                              const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int16_t x_axis,
+                              const int16_t y_axis, const int16_t z_axis);
 
 /** A data block containing information about acceleration. */
 typedef struct acceleration_data_block {
-    uint8_t bytes[12];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Linear acceleration in the x-axis measured in centimetres per second squared. */
+    int16_t x;
+    /** Linear acceleration in the y-axis measured in centimetres per second squared. */
+    int16_t y;
+    /** Linear acceleration in the z-axis measured in centimetres per second squared. */
+    int16_t z;
+    /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
+    int16_t _padding;
 } AccelerationDB;
 
-void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int8_t full_scale_range,
-                          const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
+void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
+                          const int16_t z_axis);
 
 /** A data block containing location information provided by a GNSS sensor */
 typedef struct gnss_location_data_block {

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -92,15 +92,6 @@ typedef struct {
 void block_header_init(BlockHeader *b, const uint16_t length, const BlockType type, const BlockSubtype subtype,
                        const DeviceAddress dest);
 
-/** Signal report for the last block that was sent by the block's destination device */
-typedef struct signal_report_block {
-    /** The signal block report accessed as a bytes array */
-    uint8_t bytes[4];
-} SignalReportBlock;
-
-void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rssi, const uint8_t radio,
-                        const int8_t tx_power, const bool request);
-
 /** A data block containing information about altitude. */
 typedef struct {
     /** The altitude data block accessed as a bytes array */

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -166,15 +166,6 @@ typedef struct acceleration_data_block {
 void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
                           const int16_t z_axis);
 
-/** A data block containing location information provided by a GNSS sensor */
-typedef struct gnss_location_data_block {
-    uint8_t bytes[32];
-} GNSSLocationDB;
-
-void gnss_location_db_init(GNSSLocationDB *b, const uint32_t fix_time, const int32_t latitude, const int32_t longitude,
-                           const uint32_t utc_time, const int32_t altitude, int16_t speed, int16_t course,
-                           uint16_t pdop, uint16_t hdop, uint16_t vdop, uint8_t sats, uint8_t fix);
-
 /** Represents a radio packet block with variable length contents. */
 typedef struct {
     /** The block header. Block length is encoded here. */

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -122,8 +122,10 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 
 /** A data block containing information about pressure. */
 typedef struct {
-    /** The pressure data block can be accessed as a bytes array. */
-    uint8_t bytes[8];
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Pressure measured in Pascals. */
+    uint32_t pressure;
 } PressureDB;
 
 void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure);

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -141,40 +141,6 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 }
 
 /**
- * Initializes a GNSS location data block with the provided information
- * @param b The GNSS location data block to be initialized
- * @param fix_time The mission time the fix was recieved
- * @param latitude The latitude of the rocket in units of 100 micro-arcminutes per LSB
- * @param longitude The longitude of the rocket in units of 100 micro-arcminutes per LSB
- * @param utc_time The UTC time when the fix was recieved
- * @param altitude The altitude calculated by the GNSS module, in mm
- * @param speed The speed over the ground in hundredths of a knot
- * @param course The course over ground of the rocket in hundredths of a degree
- * @param pdop Position dilution of precision multiplied by 100
- * @param hdop Horizontal dilution of precision multipled by 100
- * @param vdop Vertical dilution of precision multiplied by 100
- * @param sats The number of GNSS satellites used in the fix
- * @param fix The fix type, as two bits
- */
-void gnss_location_db_init(GNSSLocationDB *b, const uint32_t fix_time, const int32_t latitude, const int32_t longitude,
-                           const uint32_t utc_time, const int32_t altitude, int16_t speed, int16_t course,
-                           uint16_t pdop, uint16_t hdop, uint16_t vdop, uint8_t sats, uint8_t fix) {
-    // Could write this all out with sizeofs, but it gets really hard to read after a second
-    memcpy(b->bytes, &fix_time, sizeof(fix_time));
-    memcpy(b->bytes + (4), &latitude, sizeof(latitude));
-    memcpy(b->bytes + (4 * 2), &longitude, sizeof(longitude));
-    memcpy(b->bytes + (4 * 3), &utc_time, sizeof(utc_time));
-    memcpy(b->bytes + (4 * 4), &altitude, sizeof(altitude));
-    memcpy(b->bytes + (4 * 4), &speed, sizeof(speed));
-    memcpy(b->bytes + (4 * 4) + sizeof(speed), &course, sizeof(course));
-    memcpy(b->bytes + (4 * 4) + sizeof(speed) + sizeof(course), &pdop, sizeof(pdop));
-    memcpy(b->bytes + (4 * 4) + sizeof(speed) + sizeof(course) + sizeof(pdop), &hdop, sizeof(hdop));
-    memcpy(b->bytes + (4 * 4) + sizeof(speed) + sizeof(course) + sizeof(pdop) + sizeof(hdop), &vdop, sizeof(vdop));
-    b->bytes[31] = sats;
-    b->bytes[32] = (uint8_t)((fix & 0x03) << 6);
-}
-
-/**
  * Appends a block to a packet. WARNING: This function assumes that there is sufficient memory in the packet to store
  * the block.
  * @param p The packet to be appended to.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -93,8 +93,8 @@ void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const in
  * @param pressure The calculated pressure in units of Pascals.
  */
 void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure) {
-    memcpy(b->bytes, &mission_time, sizeof(mission_time));
-    memcpy(b->bytes + sizeof(mission_time), &pressure, sizeof(pressure));
+    b->mission_time = mission_time;
+    b->pressure = pressure;
 }
 
 /**
@@ -133,10 +133,9 @@ void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const 
     memcpy(b->bytes + sizeof(mission_time), &full_scale_range, sizeof(full_scale_range));
     // One byte of dead space after FSR
     memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis,
-           sizeof(y_axis));
-    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis),
-           &z_axis, sizeof(z_axis));
+    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
+    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis), &z_axis,
+           sizeof(z_axis));
 }
 
 /**

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -145,8 +145,8 @@ void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const 
  * @param humidity The calculated humidity in ten thousandths of a percent.
  */
 void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity) {
-    memcpy(b->bytes, &mission_time, sizeof(mission_time));
-    memcpy(b->bytes + sizeof(mission_time), &humidity, sizeof(humidity));
+    b->mission_time = mission_time;
+    b->humidity = humidity;
 }
 
 /**

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -67,75 +67,75 @@ void block_header_init(BlockHeader *b, const uint16_t length, const BlockType ty
 /**
  * Initializes an altitude data block with the provided information.
  * @param b The altitude data to be initialized
- * @param measurement_time The mission time at the taking of the measurement
- * @param altitude The calculated altitude in units of 1 mm/LSB.
+ * @param mission_time The mission time at the taking of the measurement
+ * @param altitude The calculated altitude in units millimetres above/below launch height.
  */
-void altitude_db_init(AltitudeDB *b, const uint32_t measurement_time, const int32_t altitude) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &altitude, sizeof(altitude));
+void altitude_db_init(AltitudeDB *b, const uint32_t mission_time, const int32_t altitude) {
+    b->mission_time = mission_time;
+    b->altitude = altitude;
 }
 
 /**
  * Initializes a temperature data block with the provided information.
  * @param b The temperature data block to be initialized.
- * @param measurement_time The mission time at the taking of the measurement
+ * @param mission_time The mission time at the taking of the measurement
  * @param temperature The calculated temperature in units of millidegrees Celsius.
  */
-void temperature_db_init(TemperatureDB *b, const uint32_t measurement_time, const int32_t temperature) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &temperature, sizeof(temperature));
+void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const int32_t temperature) {
+    b->mission_time = mission_time;
+    b->temperature = temperature;
 }
 
 /**
  * Initializes a temperature data block with the provided information.
  * @param b The temperature data block to be initialized.
- * @param measurement_time The mission time at the taking of the measurement
+ * @param mission_time The mission time at the taking of the measurement
  * @param pressure The calculated pressure in units of Pascals.
  */
-void pressure_db_init(PressureDB *b, const uint32_t measurement_time, const int32_t pressure) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &pressure, sizeof(pressure));
+void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure) {
+    memcpy(b->bytes, &mission_time, sizeof(mission_time));
+    memcpy(b->bytes + sizeof(mission_time), &pressure, sizeof(pressure));
 }
 
 /**
  * Initializes an angular velocity block with the provided information.
  * @param b The angular velocity block to be initialized.
- * @param measurement_time The mission time when the measurement was taken.
+ * @param mission_time The mission time when the measurement was taken.
  * @param full_scale_range The full scale range of the gyroscope in degrees per second. This value represents the
  * maximum and minimum angular velocity that can be measured.
  * @param x_axis The angular velocity measurement for the x axis.
  * @param y_axis The angular velocity measurement for the y axis.
  * @param z_axis The angular velocity measurement for the z axis.
  */
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int8_t full_scale_range,
                               const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
-    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
-    memcpy(b->bytes + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(y_axis), &z_axis,
+    memcpy(b->bytes, &mission_time, sizeof(mission_time));
+    memcpy(b->bytes + sizeof(mission_time), &full_scale_range, sizeof(full_scale_range));
+    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
+    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
+    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(y_axis), &z_axis,
            sizeof(z_axis));
 }
 
 /**
  * Initializes an acceleration data block with the provided information.
  * @param b The acceleration data block to be initialized.
- * @param measurement_time The mission time when the measurement was taken.
+ * @param mission_time The mission time when the measurement was taken.
  * @param full_scale_range The full scale range of the gyroscope in degrees per second. This value represents the
  * maximum and minimum acceleration that can be measured.
  * @param x_axis The acceleration measurement for the x axis.
  * @param y_axis The acceleration measurement for the y axis.
  * @param z_axis The acceleration measurement for the z axis.
  * */
-void acceleration_db_init(AccelerationDB *b, const uint32_t measurement_time, const int8_t full_scale_range,
+void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int8_t full_scale_range,
                           const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &full_scale_range, sizeof(full_scale_range));
+    memcpy(b->bytes, &mission_time, sizeof(mission_time));
+    memcpy(b->bytes + sizeof(mission_time), &full_scale_range, sizeof(full_scale_range));
     // One byte of dead space after FSR
-    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis,
+    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
+    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis,
            sizeof(y_axis));
-    memcpy(b->bytes + 1 + sizeof(measurement_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis),
+    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis),
            &z_axis, sizeof(z_axis));
 }
 
@@ -168,12 +168,12 @@ void telemetry_request_block_init(TelemetryRequestBlock *b, const uint8_t data_s
 /**
  * Initializes a humidity data block with the provided information.
  * @param b The humidity data block to be initialized.
- * @param measurement_time The mission time at the taking of the measurement
+ * @param mission_time The mission time at the taking of the measurement
  * @param humidity The calculated humidity in ten thousandths of a percent.
  */
-void humidity_db_init(HumidityDB *b, const uint32_t measurement_time, const uint32_t humidity) {
-    memcpy(b->bytes, &measurement_time, sizeof(measurement_time));
-    memcpy(b->bytes + sizeof(measurement_time), &humidity, sizeof(humidity));
+void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity) {
+    memcpy(b->bytes, &mission_time, sizeof(mission_time));
+    memcpy(b->bytes + sizeof(mission_time), &humidity, sizeof(humidity));
 }
 
 /**

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -65,24 +65,6 @@ void block_header_init(BlockHeader *b, const uint16_t length, const BlockType ty
 }
 
 /**
- * Initializes a signal report block with the provided information.
- * @param b The signal report to be initialized
- * @param snr The signal to noise ratio, in units of 1dB/LSB
- * @param rssi The received signal strength indication, in units of 1dB/LSB
- * @param radio The index of the radio that is making a request for the signal report
- * @param tx_power The power with which a signal report is sent
- * @param request 1 if this is a request for a report, 0 if this is a report
- */
-void signal_report_init(SignalReportBlock *b, const int8_t snr, const int8_t rssi, const uint8_t radio,
-                        const int8_t tx_power, const bool request) {
-    b->bytes[0] = snr;                         // SNR fills first byte completely
-    b->bytes[1] = rssi;                        // RSSI fills second byte completely
-    b->bytes[2] = (uint8_t)(radio & 0x3) << 6; // Last two bits at start of byte
-    b->bytes[2] |= (uint8_t)(tx_power & 0x3F); // Fill the rest of the six bits
-    b->bytes[3] = (uint8_t)(request & 0x1);    // Set dead space and request indicator
-}
-
-/**
  * Initializes an altitude data block with the provided information.
  * @param b The altitude data to be initialized
  * @param measurement_time The mission time at the taking of the measurement

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -101,41 +101,32 @@ void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t 
  * Initializes an angular velocity block with the provided information.
  * @param b The angular velocity block to be initialized.
  * @param mission_time The mission time when the measurement was taken.
- * @param full_scale_range The full scale range of the gyroscope in degrees per second. This value represents the
- * maximum and minimum angular velocity that can be measured.
- * @param x_axis The angular velocity measurement for the x axis.
- * @param y_axis The angular velocity measurement for the y axis.
- * @param z_axis The angular velocity measurement for the z axis.
+ * @param x_axis The angular velocity measurement for the x axis in tenths of degrees per second.
+ * @param y_axis The angular velocity measurement for the y axis in tenths of degrees per second.
+ * @param z_axis The angular velocity measurement for the z axis in tenths of degrees per second.
  */
-void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int8_t full_scale_range,
-                              const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
-    memcpy(b->bytes, &mission_time, sizeof(mission_time));
-    memcpy(b->bytes + sizeof(mission_time), &full_scale_range, sizeof(full_scale_range));
-    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
-    memcpy(b->bytes + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(y_axis), &z_axis,
-           sizeof(z_axis));
+void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int16_t x_axis,
+                              const int16_t y_axis, const int16_t z_axis) {
+    b->mission_time = mission_time;
+    b->x = x_axis;
+    b->y = y_axis;
+    b->z = z_axis;
 }
 
 /**
  * Initializes an acceleration data block with the provided information.
  * @param b The acceleration data block to be initialized.
  * @param mission_time The mission time when the measurement was taken.
- * @param full_scale_range The full scale range of the gyroscope in degrees per second. This value represents the
- * maximum and minimum acceleration that can be measured.
- * @param x_axis The acceleration measurement for the x axis.
- * @param y_axis The acceleration measurement for the y axis.
- * @param z_axis The acceleration measurement for the z axis.
+ * @param x_axis The acceleration measurement for the x axis in centimetres per second squared.
+ * @param y_axis The acceleration measurement for the y axis in centimetres per second squared.
+ * @param z_axis The acceleration measurement for the z axis in centimetres per second squared.
  * */
-void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int8_t full_scale_range,
-                          const int16_t x_axis, const int16_t y_axis, const int16_t z_axis) {
-    memcpy(b->bytes, &mission_time, sizeof(mission_time));
-    memcpy(b->bytes + sizeof(mission_time), &full_scale_range, sizeof(full_scale_range));
-    // One byte of dead space after FSR
-    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range), &x_axis, sizeof(x_axis));
-    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis), &y_axis, sizeof(y_axis));
-    memcpy(b->bytes + 1 + sizeof(mission_time) + sizeof(full_scale_range) + sizeof(x_axis) + sizeof(z_axis), &z_axis,
-           sizeof(z_axis));
+void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
+                          const int16_t z_axis) {
+    b->mission_time = mission_time;
+    b->x = x_axis;
+    b->y = y_axis;
+    b->z = z_axis;
 }
 
 /**

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -140,32 +140,6 @@ void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const 
 }
 
 /**
- * Initializes a telemetry data block with the provided information.
- * @param b The telemetry request block to be initialized.
- * @param data_subtype_1 The first requested data type.
- * @param used_1 A boolean to determine if the first data request is valid.
- * @param data_subtype_2 The second requested data type.
- * @param used_2 A boolean to determine if the second data request is valid.
- * @param data_subtype_3 The third requested data type.
- * @param used_3 A boolean to determine if the third data request is valid.
- * @param data_subtype_4 The fourth requested data type.
- * @param used_4 A boolean to determine if the fourth data request is valid.
- * */
-void telemetry_request_block_init(TelemetryRequestBlock *b, const uint8_t data_subtype_1, const uint8_t used_1,
-                                  const uint8_t data_subtype_2, const uint8_t used_2, const uint8_t data_subtype_3,
-                                  const uint8_t used_3, const uint8_t data_subtype_4, const uint8_t used_4) {
-
-    b->bytes[0] = data_subtype_1 << 2;
-    b->bytes[0] |= used_1 && 0x01;
-    b->bytes[1] = data_subtype_2 << 2;
-    b->bytes[1] |= used_2 && 0x01;
-    b->bytes[2] = data_subtype_3 << 2;
-    b->bytes[2] |= used_3 && 0x01;
-    b->bytes[3] = data_subtype_4 << 2;
-    b->bytes[3] |= used_4 && 0x01;
-}
-
-/**
  * Initializes a humidity data block with the provided information.
  * @param b The humidity data block to be initialized.
  * @param mission_time The mission time at the taking of the measurement


### PR DESCRIPTION
This closes #54.

Gone are the days of bit shifting and byte arrays. The future is now, and the future is a packet encoding that respects standard integer sizes!

All packet encodings now use regular C structs with appropriately sized members to represent data in the packet spec. They can be casted to bytes for transmission, but can also have their members accessed by regular namespace accesses for convenient programming.