### PR TITLE
Mqueue out

### DIFF
--- a/packager.use
+++ b/packager.use
@@ -9,10 +9,11 @@ DESCRIPTION:
     A command line utility for packaging sensor data into radio format.
 
 SYNTAX:
-    packager [-i file -o file] callsign
+    packager [-i file -p] callsign
 
 OPTIONS:
     -i file         The file or pipe to read sensor data from. If none is 
                     provided, data will be read from stdin.
-    -o file         The file or pipe to write packets to. If none is provided,
-                    data will be written to stdout.
+
+    -p              If this flag is passed, packets will be printed to stdout in
+                    hex format.

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -72,7 +72,7 @@ typedef struct {
     uint8_t src_addr;
     /** Which number this packet is in the stream of sent packets. */
     uint32_t packet_num;
-} TIGHTLY_PACKED PacketHeader;
+} PacketHeader;
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t length, const uint8_t version,
                         const DeviceAddress source, const uint32_t packet_number);
@@ -98,7 +98,7 @@ typedef struct {
     uint32_t mission_time;
     /** Altitude in units of millimetres above/below the launch height. */
     int32_t altitude;
-} TIGHTLY_PACKED AltitudeDB;
+} AltitudeDB;
 
 void altitude_db_init(AltitudeDB *b, const uint32_t mission_time, const int32_t altitude);
 
@@ -108,7 +108,7 @@ typedef struct {
     uint32_t mission_time;
     /** Temperature in millidegrees Celsius. */
     int32_t temperature;
-} TIGHTLY_PACKED TemperatureDB;
+} TemperatureDB;
 
 void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const int32_t temperature);
 
@@ -118,7 +118,7 @@ typedef struct {
     uint32_t mission_time;
     /** Relative humidity in ten thousandths of a percent. */
     uint32_t humidity;
-} TIGHTLY_PACKED HumidityDB;
+} HumidityDB;
 
 void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity);
 
@@ -128,7 +128,7 @@ typedef struct {
     uint32_t mission_time;
     /** Pressure measured in Pascals. */
     uint32_t pressure;
-} TIGHTLY_PACKED PressureDB;
+} PressureDB;
 
 void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure);
 
@@ -144,7 +144,7 @@ typedef struct {
     int16_t z;
     /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
     int16_t _padding;
-} TIGHTLY_PACKED AngularVelocityDB;
+} AngularVelocityDB;
 
 void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int16_t x_axis,
                               const int16_t y_axis, const int16_t z_axis);
@@ -161,12 +161,11 @@ typedef struct acceleration_data_block {
     int16_t z;
     /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
     int16_t _padding;
-} TIGHTLY_PACKED AccelerationDB;
+} AccelerationDB;
 
 void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
                           const int16_t z_axis);
 
-bool packet_append_block(uint8_t *p, const BlockHeader bh);
 void packet_print_hex(FILE *stream, uint8_t *packet);
 
 /**
@@ -184,6 +183,15 @@ static inline void packet_header_set_length(PacketHeader *p, const uint16_t leng
  * @return The length of the packet header in bytes, including itself.
  */
 static inline uint16_t packet_header_get_length(const PacketHeader *p) { return (p->len + 1) * 4; }
+
+/**
+ * Increments the length of the packet header.
+ * @param p The packet header change the length of.
+ * @param l The additional length (in bytes) to add to the packet length.
+ */
+static inline void packet_header_inc_length(PacketHeader *p, const uint16_t l) {
+    packet_header_set_length(p, packet_header_get_length(p) + l - sizeof(PacketHeader));
+}
 
 /**
  * Sets the length of the block the block header is associated with.

--- a/src/include/packet_types.h
+++ b/src/include/packet_types.h
@@ -72,7 +72,7 @@ typedef struct {
     uint8_t src_addr;
     /** Which number this packet is in the stream of sent packets. */
     uint32_t packet_num;
-} PacketHeader;
+} TIGHTLY_PACKED PacketHeader;
 
 void packet_header_init(PacketHeader *p, const char *callsign, const uint16_t length, const uint8_t version,
                         const DeviceAddress source, const uint32_t packet_number);
@@ -98,7 +98,7 @@ typedef struct {
     uint32_t mission_time;
     /** Altitude in units of millimetres above/below the launch height. */
     int32_t altitude;
-} AltitudeDB;
+} TIGHTLY_PACKED AltitudeDB;
 
 void altitude_db_init(AltitudeDB *b, const uint32_t mission_time, const int32_t altitude);
 
@@ -108,7 +108,7 @@ typedef struct {
     uint32_t mission_time;
     /** Temperature in millidegrees Celsius. */
     int32_t temperature;
-} TemperatureDB;
+} TIGHTLY_PACKED TemperatureDB;
 
 void temperature_db_init(TemperatureDB *b, const uint32_t mission_time, const int32_t temperature);
 
@@ -118,7 +118,7 @@ typedef struct {
     uint32_t mission_time;
     /** Relative humidity in ten thousandths of a percent. */
     uint32_t humidity;
-} HumidityDB;
+} TIGHTLY_PACKED HumidityDB;
 
 void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t humidity);
 
@@ -128,7 +128,7 @@ typedef struct {
     uint32_t mission_time;
     /** Pressure measured in Pascals. */
     uint32_t pressure;
-} PressureDB;
+} TIGHTLY_PACKED PressureDB;
 
 void pressure_db_init(PressureDB *b, const uint32_t mission_time, const int32_t pressure);
 
@@ -144,7 +144,7 @@ typedef struct {
     int16_t z;
     /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
     int16_t _padding;
-} AngularVelocityDB;
+} TIGHTLY_PACKED AngularVelocityDB;
 
 void angular_velocity_db_init(AngularVelocityDB *b, const uint32_t mission_time, const int16_t x_axis,
                               const int16_t y_axis, const int16_t z_axis);
@@ -161,31 +161,13 @@ typedef struct acceleration_data_block {
     int16_t z;
     /** 0 padding to fill the 4 byte multiple requirement of the packet spec. */
     int16_t _padding;
-} AccelerationDB;
+} TIGHTLY_PACKED AccelerationDB;
 
 void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
                           const int16_t z_axis);
 
-/** Represents a radio packet block with variable length contents. */
-typedef struct {
-    /** The block header. Block length is encoded here. */
-    BlockHeader header;
-    /** The block contents up to a length of 128 bytes. */
-    uint8_t *contents;
-} Block;
-
-/** Represents a packet with a variable number of blocks. Maximum of 256 bytes. */
-typedef struct {
-    /** The packet header. Packet length is encoded here. */
-    PacketHeader header;
-    /** Packet contents in blocks, up to 256 bytes long. */
-    Block *blocks;
-    /** The number of blocks in this packet. */
-    uint8_t block_count;
-} Packet;
-
-bool packet_append_block(Packet *p, const Block b);
-void packet_print_hex(FILE *stream, Packet *packet);
+bool packet_append_block(uint8_t *p, const BlockHeader bh);
+void packet_print_hex(FILE *stream, uint8_t *packet);
 
 /**
  * Sets the length of the packet the header is associated with.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -141,30 +141,6 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 }
 
 /**
- * Appends a block to a packet.
- * WARNING: This function assumes that there is sufficient memory in the packet to store the block.
- * @param p The packet to be appended to.
- * @param b The block to append.
- * @return True if the append succeeded, false if there was no space to append the block.
- */
-bool packet_append_block(uint8_t *p, const BlockHeader bh) {
-
-    const uint16_t p_len = packet_header_get_length((PacketHeader *)p);
-    const uint16_t b_len = block_header_get_length(&bh);
-
-    // Ensure that there is enough space for the block to be added to the packet
-    if (p_len + b_len > PACKET_MAX_SIZE) return false;
-
-    // Add the block at the end of the packet
-    *(BlockHeader *)(p + p_len) = bh;
-
-    // Update packet length
-    packet_header_set_length((PacketHeader *)p, p_len + b_len);
-
-    return true;
-}
-
-/**
  * Prints a packet to the output stream in hexadecimal representation.
  * @param stream The output stream to which the packet should be printed.
  * @param packet The packet to be printed.

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -147,54 +147,31 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
  * @param b The block to append.
  * @return True if the append succeeded, false if there was no space to append the block.
  */
-bool packet_append_block(Packet *p, const Block b) {
+bool packet_append_block(uint8_t *p, const BlockHeader bh) {
 
-    const uint16_t p_len = packet_header_get_length(&p->header);
-    const uint16_t b_len = block_header_get_length(&b.header);
+    const uint16_t p_len = packet_header_get_length((PacketHeader *)p);
+    const uint16_t b_len = block_header_get_length(&bh);
 
     // Ensure that there is enough space for the block to be added to the packet
     if (p_len + b_len > PACKET_MAX_SIZE) return false;
 
-    // If packet is just a header, first block goes in slot 0
-    if (p_len == sizeof(PacketHeader)) {
-        p->blocks[0] = b;
-        packet_header_set_length(&p->header, b_len); // The packet is now the length of the first block
-        p->block_count++;
-        return true;
-    }
+    // Add the block at the end of the packet
+    *(BlockHeader *)(p + p_len) = bh;
 
-    uint16_t remaining_len = p_len;
-    remaining_len -= sizeof(PacketHeader);                          // Subtract packet header length
-    remaining_len -= block_header_get_length(&p->blocks[0].header); // Subtract length of first block
+    // Update packet length
+    packet_header_set_length((PacketHeader *)p, p_len + b_len);
 
-    // While there is still content left in the packet, get the next block
-    uint16_t i = 1;
-    for (; remaining_len > 0; i++) {
-        remaining_len -= block_header_get_length(&p->blocks[i].header);
-    }
-    p->blocks[i] = b; // Add block at correct spot
-    // Packet length is now equal to its previous length + the new block
-    packet_header_set_length(&p->header, p_len - sizeof(PacketHeader) + b_len);
-    p->block_count++;
     return true;
 }
-
-#define write_bytes_sized(stream, bytes, size)                                                                         \
-    for (size_t hjkl = 0; hjkl < size; hjkl++) {                                                                       \
-        fprintf(stream, "%02x", bytes[hjkl]);                                                                          \
-    }
 
 /**
  * Prints a packet to the output stream in hexadecimal representation.
  * @param stream The output stream to which the packet should be printed.
  * @param packet The packet to be printed.
  */
-void packet_print_hex(FILE *stream, Packet *packet) {
-    write_bytes_sized(stream, ((uint8_t *)(&packet->header)), sizeof(packet->header));
-    for (uint8_t i = 0; i < packet->block_count; i++) {
-        write_bytes_sized(stream, ((uint8_t *)(&packet->blocks[i].header)), sizeof(packet->blocks[i].header));
-        uint16_t content_len = block_header_get_length(&packet->blocks[i].header) - sizeof(packet->blocks[i].header);
-        write_bytes_sized(stream, packet->blocks[i].contents, content_len);
+void packet_print_hex(FILE *stream, uint8_t *packet) {
+    for (uint32_t i = 0; i < packet_header_get_length((PacketHeader *)(packet)); i++) {
+        fprintf(stream, "%02x", packet[i]);
     }
     fputc('\n', stream);
 }

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -141,8 +141,8 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 }
 
 /**
- * Appends a block to a packet. WARNING: This function assumes that there is sufficient memory in the packet to store
- * the block.
+ * Appends a block to a packet.
+ * WARNING: This function assumes that there is sufficient memory in the packet to store the block.
  * @param p The packet to be appended to.
  * @param b The block to append.
  * @return True if the append succeeded, false if there was no space to append the block.


### PR DESCRIPTION
This PR implements a message queue for sending out encoded packets from packager; one step closer to removing the shell dependency.

The `-p` flag can still be passed to print output.

Closes #64.