### PR TITLE
Added support for encoding the relative types to packager

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -151,14 +151,15 @@ int main(int argc, char **argv) {
             case TAG_ALTITUDE_REL:
             case TAG_ALTITUDE_SEA:
                 just_added_block_size = sizeof(AltitudeDB);
-                add_block_header(DATA_ALT, just_added_block_size);
+                add_block_header(buffer[0] == TAG_ALTITUDE_SEA ? DATA_ALT_SEA : DATA_ALT_LAUNCH, just_added_block_size);
                 altitude_db_init((AltitudeDB *)packet_pos, last_time, 1000 * dref_cast(float, data));
                 break;
 
             case TAG_LINEAR_ACCEL_ABS:
             case TAG_LINEAR_ACCEL_REL:
                 just_added_block_size = sizeof(AccelerationDB);
-                add_block_header(DATA_ACCEL, just_added_block_size);
+                add_block_header(buffer[0] == TAG_LINEAR_ACCEL_REL ? DATA_ACCEL_REL : DATA_ACCEL_ABS,
+                                 just_added_block_size);
                 acceleration_db_init((AccelerationDB *)packet_pos, last_time, dref_cast(vec3d_t, data).x * 100,
                                      dref_cast(vec3d_t, data).y * 100, dref_cast(vec3d_t, data).z * 100);
                 break;

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -141,6 +141,19 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 }
 
 /**
+ * Initializes a humidity data block with the provided information.
+ * @param b The humidity data block to be initialized.
+ * @param mission_time The mission time at the taking of the measurement.
+ * @param lat The latitude coordinate component in degrees/LSB.
+ * @param long The longitude coordinate component in degrees/LSB.
+ */
+void coordinate_db_init(CoordinateDB *b, const uint32_t mission_time, const int32_t lat, const int32_t lon) {
+    b->mission_time = mission_time;
+    b->latitude = lat;
+    b->longitude = lon;
+}
+
+/**
  * Prints a packet to the output stream in hexadecimal representation.
  * @param stream The output stream to which the packet should be printed.
  * @param packet The packet to be printed.

--- a/src/packet_types.h
+++ b/src/packet_types.h
@@ -47,14 +47,15 @@ typedef enum block_type {
 /** Possible sub-types of data blocks that can be sent. */
 typedef enum data_block_type {
     DATA_DBG_MSG = 0x0,     /**< Debug message */
-    DATA_ALT = 0x1,         /**< Altitude data */
-    DATA_TEMP = 0x2,        /**< Temperature data */
-    DATA_PRESSURE = 0x3,    /**< Pressure data */
-    DATA_ACCEL = 0x4,       /**< Acceleration data */
-    DATA_ANGULAR_VEL = 0x5, /**< Angular velocity data */
-    DATA_GNSS_LOC = 0x6,    /**< GNSS location data */
-    DATA_GNSS_META = 0x7,   /**< GNSS metadata */
+    DATA_ALT_SEA = 0x1,     /**< Altitude above sea level */
+    DATA_ALT_LAUNCH = 0x2,  /**< Altitude above launch level */
+    DATA_TEMP = 0x3,        /**< Temperature data */
+    DATA_PRESSURE = 0x4,    /**< Pressure data */
+    DATA_ACCEL_REL = 0x5,   /**< Relative linear acceleration data */
+    DATA_ACCEL_ABS = 0x6,   /**< Absolute linear acceleration data (relative to ground) */
+    DATA_ANGULAR_VEL = 0x7, /**< Angular velocity data */
     DATA_HUMIDITY = 0x8,    /**< Humidity data */
+    DATA_LAT_LONG = 0x9,    /**< Latitude and longitude coordinates */
 } DataBlockType;
 
 /** Any block sub-type from DataBlockType, CtrlBlockType or CmdBlockType. */
@@ -165,6 +166,18 @@ typedef struct acceleration_data_block {
 
 void acceleration_db_init(AccelerationDB *b, const uint32_t mission_time, const int16_t x_axis, const int16_t y_axis,
                           const int16_t z_axis);
+
+/** A data block containing latitude and longitude coordinates. */
+typedef struct {
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Latitude in degrees/LSB. */
+    int32_t latitude;
+    /** Longitude in degrees/LSB. */
+    int32_t longitude;
+} CoordinateDB;
+
+void coordinate_db_init(CoordinateDB *b, const uint32_t mission_time, const int32_t lat, const int32_t lon);
 
 void packet_print_hex(FILE *stream, uint8_t *packet);
 

--- a/tests/test_init.c
+++ b/tests/test_init.c
@@ -34,11 +34,11 @@ bool test_packet_header_init(void) {
 bool test_block_header_init(void) {
 
     BlockHeader b;
-    block_header_init(&b, 16, TYPE_DATA, DATA_ALT, GROUNDSTATION);
+    block_header_init(&b, 16, TYPE_DATA, DATA_ALT_SEA, GROUNDSTATION);
 
     LOG_ASSERT(block_header_get_length(&b) == 16 + sizeof(b));
     LOG_ASSERT(b.type == TYPE_DATA);
-    LOG_ASSERT(b.subtype == DATA_ALT);
+    LOG_ASSERT(b.subtype == DATA_ALT_SEA);
     LOG_ASSERT(b.dest_addr == GROUNDSTATION);
     return true;
 }


### PR DESCRIPTION
Also included necessary type for the lat/long packet.

See https://github.com/CarletonURocketry/telemetry-format/pull/19.