### PR TITLE
Voltage packet

### DIFF
--- a/src/intypes.h
+++ b/src/intypes.h
@@ -26,16 +26,17 @@ typedef struct {
 
 /** Describes possible data types that fetcher is capable of producing. */
 typedef enum {
-    TAG_TEMPERATURE = 0,      /**< Temperature in degrees Celsius */
-    TAG_PRESSURE = 1,         /**< Pressure in kilo Pascals */
-    TAG_HUMIDITY = 2,         /**< Humidity in % relative humidity */
-    TAG_TIME = 3,             /**< Time in milliseconds */
-    TAG_ALTITUDE_SEA = 4,     /**< Altitude above sea level in meters */
-    TAG_ALTITUDE_REL = 5,     /**< Altitude above launch height in meters */
-    TAG_ANGULAR_VEL = 6,      /**< Angular velocity in degrees per second */
-    TAG_LINEAR_ACCEL_REL = 7, /**< Relative linear acceleration in meters per second squared */
-    TAG_LINEAR_ACCEL_ABS = 8, /**< Absolute linear acceleration in meters per second squared */
-    TAG_COORDS = 9,           /**< Latitude and longitude in degrees */
+    TAG_TEMPERATURE = 0x0,      /**< Temperature in degrees Celsius */
+    TAG_PRESSURE = 0x1,         /**< Pressure in kilo Pascals */
+    TAG_HUMIDITY = 0x2,         /**< Humidity in % relative humidity */
+    TAG_TIME = 0x3,             /**< Time in milliseconds */
+    TAG_ALTITUDE_SEA = 0x4,     /**< Altitude above sea level in meters */
+    TAG_ALTITUDE_REL = 0x5,     /**< Altitude above launch height in meters */
+    TAG_ANGULAR_VEL = 0x6,      /**< Angular velocity in degrees per second */
+    TAG_LINEAR_ACCEL_REL = 0x7, /**< Relative linear acceleration in meters per second squared */
+    TAG_LINEAR_ACCEL_ABS = 0x8, /**< Absolute linear acceleration in meters per second squared */
+    TAG_COORDS = 0x9,           /**< Latitude and longitude in degrees */
+    TAG_VOLTAGE = 0x10,         /**< Voltage in volts with a unique ID. */
 } SensorTag;
 
 #endif // _INTYPES_H_

--- a/src/main.c
+++ b/src/main.c
@@ -178,6 +178,13 @@ int main(int argc, char **argv) {
                                    dref_cast(vec2d_t, data).y);
                 break;
 
+            case TAG_VOLTAGE:
+                just_added_block_size = sizeof(VoltageDB);
+                add_block_header(DATA_VOLTAGE, just_added_block_size);
+                voltage_db_init((VoltageDB *)packet_pos, last_time, dref_cast(uint8_t, data),
+                                dref_cast(int16_t, (uint8_t *)(data) + 1));
+                break;
+
             default:
                 fprintf(stderr, "Unknown input data type: %u\n", buffer[0]);
                 continue; // Skip to next iteration without storing block

--- a/src/packet_types.c
+++ b/src/packet_types.c
@@ -141,8 +141,8 @@ void humidity_db_init(HumidityDB *b, const uint32_t mission_time, const uint32_t
 }
 
 /**
- * Initializes a humidity data block with the provided information.
- * @param b The humidity data block to be initialized.
+ * Initializes a coordinate data block with the provided information.
+ * @param b The coordinate data block to be initialized.
  * @param mission_time The mission time at the taking of the measurement.
  * @param lat The latitude coordinate component in degrees/LSB.
  * @param long The longitude coordinate component in degrees/LSB.
@@ -151,6 +151,19 @@ void coordinate_db_init(CoordinateDB *b, const uint32_t mission_time, const int3
     b->mission_time = mission_time;
     b->latitude = lat;
     b->longitude = lon;
+}
+
+/**
+ * Initializes a voltage data block with the provided information.
+ * @param b The voltage data block to be initialized.
+ * @param mission_time The mission time at the taking of the measurement.
+ * @param id The unique numerical sensor ID associated with the sensor that took the measurement.
+ * @param voltage The voltage measurement in millivolts.
+ */
+void voltage_db_init(VoltageDB *b, const uint32_t mission_time, const uint16_t id, const int16_t voltage) {
+    b->mission_time = mission_time;
+    b->id = id;
+    b->voltage = voltage;
 }
 
 /**

--- a/src/packet_types.h
+++ b/src/packet_types.h
@@ -56,6 +56,7 @@ typedef enum data_block_type {
     DATA_ANGULAR_VEL = 0x7, /**< Angular velocity data */
     DATA_HUMIDITY = 0x8,    /**< Humidity data */
     DATA_LAT_LONG = 0x9,    /**< Latitude and longitude coordinates */
+    DATA_VOLTAGE = 0xA,     /**< Voltage in millivolts with a unique ID. */
 } DataBlockType;
 
 /** Any block sub-type from DataBlockType, CtrlBlockType or CmdBlockType. */
@@ -178,6 +179,18 @@ typedef struct {
 } CoordinateDB;
 
 void coordinate_db_init(CoordinateDB *b, const uint32_t mission_time, const int32_t lat, const int32_t lon);
+
+/** A data block containing voltage measurements and an ID for the sensor with the associated voltage. */
+typedef struct {
+    /** Mission time in milliseconds since launch. */
+    uint32_t mission_time;
+    /** Unique sensor ID. */
+    uint16_t id;
+    /** Voltage in millivolts. */
+    int16_t voltage;
+} VoltageDB;
+
+void voltage_db_init(VoltageDB *b, const uint32_t mission_time, const uint16_t id, const int16_t voltage);
 
 void packet_print_hex(FILE *stream, uint8_t *packet);
 

--- a/test.mk
+++ b/test.mk
@@ -22,13 +22,15 @@ TESTDIR += $(PROJECT_ROOT)/tests
 TESTFILES += $(wildcard $(TESTDIR)/*.c)
 TESTBINS = $(patsubst %.c,%,$(TESTFILES))
 
+.PHONY: $(TESTBINS)
+
 test: WARNINGS = 
+
+test: $(TESTBINS)
 
 $(TESTBINS):
 	@gcc $(CFLAGS) $(WARNINGS) $(SRCFILES) $@.c -o $@
 	$@
-
-test: $(TESTBINS)
 
 clean:
 	@rm $(TESTBINS)

--- a/test.mk
+++ b/test.mk
@@ -22,13 +22,10 @@ TESTDIR += $(PROJECT_ROOT)/tests
 TESTFILES += $(wildcard $(TESTDIR)/*.c)
 TESTBINS = $(patsubst %.c,%,$(TESTFILES))
 
-INCLUDE_DIRS += $(PROJECT_ROOT)/src/include
-INCLUDE = $(patsubst %,-I%,$(INCLUDE_DIRS))
-
 test: WARNINGS = 
 
 $(TESTBINS):
-	@gcc $(CFLAGS) $(INCLUDE) $(WARNINGS) $(SRCFILES) $@.c -o $@
+	@gcc $(CFLAGS) $(WARNINGS) $(SRCFILES) $@.c -o $@
 	$@
 
 test: $(TESTBINS)

--- a/tests/test_init.c
+++ b/tests/test_init.c
@@ -116,7 +116,7 @@ bool test_angular_velocity_block_init(void) {
     return true;
 }
 
-/** Test that a acceleration data block can be initialized using parameters. */
+/** Test that an acceleration data block can be initialized using parameters. */
 bool test_acceleration_block_init(void) {
 
     AccelerationDB b;
@@ -127,6 +127,42 @@ bool test_acceleration_block_init(void) {
     LOG_ASSERT(b.y == 2);
     LOG_ASSERT(b.z == -3);
     LOG_ASSERT(b._padding == 0);
+
+    return true;
+}
+
+/** Test that a coordinate data block can be initialized using parameters. */
+bool test_coordinate_block_init(void) {
+
+    CoordinateDB b;
+    coordinate_db_init(&b, 1200, 2, 1500);
+
+    LOG_ASSERT(b.mission_time == 1200);
+    LOG_ASSERT(b.latitude == 2);
+    LOG_ASSERT(b.longitude == 1500);
+
+    coordinate_db_init(&b, 1, -24, -3300);
+    LOG_ASSERT(b.mission_time == 1);
+    LOG_ASSERT(b.latitude == -24);
+    LOG_ASSERT(b.longitude == -3300);
+
+    return true;
+}
+
+/** Test that a voltage data block can be initialized using parameters. */
+bool test_voltage_block_init(void) {
+
+    VoltageDB b;
+    voltage_db_init(&b, 1200, 2, 1500);
+
+    LOG_ASSERT(b.mission_time == 1200);
+    LOG_ASSERT(b.id == 2);
+    LOG_ASSERT(b.voltage == 1500);
+
+    voltage_db_init(&b, 1, 24, -3300);
+    LOG_ASSERT(b.mission_time == 1);
+    LOG_ASSERT(b.id == 24);
+    LOG_ASSERT(b.voltage == -3300);
 
     return true;
 }
@@ -145,6 +181,8 @@ int main(void) {
     RUN_TEST(test_humidity_block_init);
     RUN_TEST(test_angular_velocity_block_init);
     RUN_TEST(test_acceleration_block_init);
+    RUN_TEST(test_voltage_block_init);
+    RUN_TEST(test_coordinate_block_init);
 
     HARNESS_RESULTS();
 


### PR DESCRIPTION
As per the update to the spec here:
https://github.com/CarletonURocketry/telemetry-format/pull/21

This PR includes the voltage packet in packager and updates the tests accordingly. Some small miscellaneous changes were made to the `test.mk` file because of inconveniences found while testing.

It should be noted that decoding these packets is yet untested.